### PR TITLE
gitignore should only exclude the binary, not all folders matching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-oauth-server
+/oauth-server


### PR DESCRIPTION
required for vendoring.  merging

@sallyom bug