### PR TITLE
Bug 1750786: Fix bootstrap IdP challenges ruining RequestHeaders IdP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,4 +19,4 @@ GO_BUILD_PACKAGES :=$(strip \
 # $2 - Dockerfile path
 # $3 - context directory for image build
 # It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,origin-$(notdir $(GO_PACKAGE)),./images/Dockerfile,.)
+$(call build-image,origin-oauth-server,origin-oauth-server,./images/Dockerfile,.)

--- a/pkg/oauthserver/oauth_apiserver.go
+++ b/pkg/oauthserver/oauth_apiserver.go
@@ -104,8 +104,10 @@ func NewOAuthServerConfig(oauthConfig osinv1.OAuthConfig, userClientConfig *rest
 		oauthConfig.IdentityProviders = append(
 			[]osinv1.IdentityProvider{
 				{
-					Name:            bootstrap.BootstrapUser, // will never conflict with other IDPs due to the :
-					UseAsChallenger: true,
+					Name: bootstrap.BootstrapUser, // will never conflict with other IDPs due to the :
+					// don't set it up as challenger if RequestHeaders IdP already is set that way
+					// this would set challenging headers and break RequestHeaders IdP
+					UseAsChallenger: !isRequestHeaderSetAsChallenger(oauthConfig.IdentityProviders),
 					UseAsLogin:      true,
 					MappingMethod:   string(identitymapper.MappingMethodClaim), // irrelevant, but needs to be valid
 					Provider: runtime.RawExtension{
@@ -209,6 +211,15 @@ func getSessionSecrets(filename string) ([][]byte, error) {
 func isHTTPS(u string) bool {
 	parsedURL, err := url.Parse(u)
 	return err == nil && parsedURL.Scheme == "https"
+}
+
+func isRequestHeaderSetAsChallenger(providers []osinv1.IdentityProvider) bool {
+	for _, p := range providers {
+		if _, isRequestHeader := p.Provider.Object.(*osinv1.RequestHeaderIdentityProvider); isRequestHeader && p.UseAsChallenger {
+			return true
+		}
+	}
+	return false
 }
 
 type ExtraOAuthConfig struct {


### PR DESCRIPTION
If RequestHeaders are configured for challenges, don't set up
the bootstrap IdP for challenges either. This would otherwise
add the WWW-Authenticate header on top of the redirecting request
which then in turn causes oauth-server internal errors.