### PR TITLE
Fix pseudoversion of osincli dependency for go1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,5 +51,5 @@ require (
 
 replace (
 	github.com/RangelReale/osin => github.com/openshift/osin v1.0.1-0.20180202150137-2dc1b4316769
-	github.com/RangelReale/osincli => github.com/openshift/osincli v0.0.0-20190724130521-fababb0555f2
+	github.com/RangelReale/osincli => github.com/openshift/osincli v0.0.0-20160924135400-fababb0555f2
 )

--- a/go.sum
+++ b/go.sum
@@ -194,8 +194,8 @@ github.com/openshift/library-go v0.0.0-20190923093227-76b67dd70a86 h1:IU+umCUKn3
 github.com/openshift/library-go v0.0.0-20190923093227-76b67dd70a86/go.mod h1:NBttNjZpWwup/nthuLbPAPSYC8Qyo+BBK5bCtFoyYjo=
 github.com/openshift/osin v1.0.1-0.20180202150137-2dc1b4316769 h1:jTaxjdXcD89WEuNXU/R+ByAMhcI3ETa6Y/o4V9v0s9Q=
 github.com/openshift/osin v1.0.1-0.20180202150137-2dc1b4316769/go.mod h1:/gGuqQHvGNST0GB+Pomi3398FTdcM+9UaXafpqHvfDM=
-github.com/openshift/osincli v0.0.0-20190724130521-fababb0555f2 h1:BQijuR1b+/aK5oMNrYo8VcPzFqkrDyY/QI3uh43EKIY=
-github.com/openshift/osincli v0.0.0-20190724130521-fababb0555f2/go.mod h1:Riv9DbfKiX3y9ebcS4PHU4zLhVXu971+4jCVwKIue5M=
+github.com/openshift/osincli v0.0.0-20160924135400-fababb0555f2 h1:9oADVMmPa4G60MQtoSjD26aD/vZreqbIAfiUiO220eY=
+github.com/openshift/osincli v0.0.0-20160924135400-fababb0555f2/go.mod h1:Riv9DbfKiX3y9ebcS4PHU4zLhVXu971+4jCVwKIue5M=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/PuerkitoBio/purell
 github.com/PuerkitoBio/urlesc
 # github.com/RangelReale/osin v0.0.0 => github.com/openshift/osin v1.0.1-0.20180202150137-2dc1b4316769
 github.com/RangelReale/osin
-# github.com/RangelReale/osincli v0.0.0 => github.com/openshift/osincli v0.0.0-20190724130521-fababb0555f2
+# github.com/RangelReale/osincli v0.0.0 => github.com/openshift/osincli v0.0.0-20160924135400-fababb0555f2
 github.com/RangelReale/osincli
 # github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
 github.com/beorn7/perks/quantile


### PR DESCRIPTION
Addressing:
```
$ make build
go: github.com/openshift/osincli@v0.0.0-20190724130521-fababb0555f2: invalid pseudo-version: does not match version-control timestamp (2016-09-24T13:54:00Z)
make: Nothing to be done for 'build'.
```

When extracting a module from a version control system, the go command now performs additional validation on the requested version string. More information can be found at https://tip.golang.org/doc/go1.13#version-validation