### PR TITLE
cleanup dead code in default auth handlers

### DIFF
--- a/pkg/oauth/handlers/default_auth_handler.go
+++ b/pkg/oauth/handlers/default_auth_handler.go
@@ -115,11 +115,7 @@ func (authHandler *unionAuthenticationHandler) AuthenticationNeeded(apiClient au
 				w.WriteHeader(http.StatusFound)
 			default:
 				w.WriteHeader(http.StatusUnauthorized)
-				ctx := req.Context()
-				if !ok {
-					return false, fmt.Errorf("no context found for request to audit")
-				}
-				ev := request.AuditEventFrom(ctx)
+				ev := request.AuditEventFrom(req.Context())
 				if ev != nil {
 					// this code mimics the bits from k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go
 					// but since we don't accept failedHander here we need to manually alter the audit


### PR DESCRIPTION
Cleaning up a conditional statement as it looks like a dead code and the boolean it is testing is evaluated much before [here](https://github.com/vareti/oauth-server/blob/485191656294201658b8014886683fd491911bc3/pkg/oauth/handlers/default_auth_handler.go#L83)