### PR TITLE
Switch to sha256~ access+authorize token storage format

### DIFF
--- a/pkg/osinserver/tokengen.go
+++ b/pkg/osinserver/tokengen.go
@@ -30,7 +30,7 @@ func randomToken() string {
 type TokenGen struct{}
 
 func (TokenGen) GenerateAuthorizeToken(data *osin.AuthorizeData) (ret string, err error) {
-	return randomToken(), nil
+	return crypto.SHA256Prefix + randomToken(), nil
 }
 
 func (TokenGen) GenerateAccessToken(data *osin.AccessData, generaterefresh bool) (string, string, error) {
@@ -41,5 +41,5 @@ func (TokenGen) GenerateAccessToken(data *osin.AccessData, generaterefresh bool)
 		refreshtoken = randomToken()
 	}
 
-	return accesstoken, refreshtoken, nil
+	return crypto.SHA256Prefix + accesstoken, refreshtoken, nil
 }

--- a/pkg/server/crypto/sha256.go
+++ b/pkg/server/crypto/sha256.go
@@ -1,0 +1,21 @@
+package crypto
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+)
+
+const SHA256Prefix = "sha256~"
+
+func TrimSHA256Prefix(code string) (string, bool) {
+	if !strings.HasPrefix(code, SHA256Prefix) {
+		return code, false
+	}
+	return strings.TrimPrefix(code, SHA256Prefix), true
+}
+
+func SHA256Token(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return SHA256Prefix + base64.RawURLEncoding.EncodeToString(h[0:])
+}

--- a/pkg/server/tokenrequest/tokenrequest.go
+++ b/pkg/server/tokenrequest/tokenrequest.go
@@ -15,10 +15,12 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog"
 
-	"github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	v1 "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	bootstrap "github.com/openshift/library-go/pkg/authentication/bootstrapauthenticator"
 	"github.com/openshift/library-go/pkg/oauth/oauthdiscovery"
+
 	oauthserver "github.com/openshift/oauth-server/pkg"
+	"github.com/openshift/oauth-server/pkg/osinserver/registrystorage"
 	"github.com/openshift/oauth-server/pkg/server/csrf"
 )
 
@@ -128,7 +130,7 @@ func (t *tokenRequest) displayTokenPost(osinOAuthClient *osincli.Client, w http.
 		return
 	}
 
-	token, err := t.tokens.Get(context.TODO(), accessData.AccessToken, metav1.GetOptions{})
+	token, err := t.tokens.Get(context.TODO(), registrystorage.TokenToObjectName(accessData.AccessToken), metav1.GetOptions{})
 	if err != nil {
 		data.Error = "Error checking token" // do not leak error to user, do not log error
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
Implement the oauth-server part of https://github.com/openshift/enhancements/pull/323 plus https://github.com/openshift/enhancements/pull/420:

- create all new access tokens in the new format by prefixing with `"sha256~` and hashing the actual token for the object name.
- still allow oauth-server to read unprefixed tokens in the osin registry code.

Depends on https://github.com/openshift/origin/pull/25374.