### PR TITLE
brings TokenReview client timeout

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,6 @@ require (
 replace (
 	github.com/RangelReale/osin => github.com/openshift/osin v1.0.1-0.20180202150137-2dc1b4316769
 	github.com/RangelReale/osincli => github.com/openshift/osincli v0.0.0-20160924135400-fababb0555f2
-	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20201019143247-401ead4ea686 // points to openshift-apiserver-4.7-kubernetes-1.19.2
+	k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20201110074854-ee87de0d9d20 // points to openshift-apiserver-4.7-kubernetes-1.19.2
 	k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20201104094117-806c7d66cfea
 )

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab h1:lB
 github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c h1:NB9g4Y/aegId7fyNqYyGxEfyNOytYFT5dxWJtfOJFQs=
 github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c/go.mod h1:yZ3u8vgWC19I9gbDMRk8//9JwG/0Sth6v7C+m6R8HXs=
-github.com/openshift/kubernetes-apiserver v0.0.0-20201019143247-401ead4ea686 h1:yTlrZWiH+yKUJ3NMl+uDnCr+yj+58nCc0GtkltpWY5I=
-github.com/openshift/kubernetes-apiserver v0.0.0-20201019143247-401ead4ea686/go.mod h1:FreAq0bJ2vtZFj9Ago/X0oNGC51GfubKK/ViOKfVAOA=
+github.com/openshift/kubernetes-apiserver v0.0.0-20201110074854-ee87de0d9d20 h1:HzCOPajn4bS3156Hsdrt9uY36aR/I/G8nJ29DI+Dm+o=
+github.com/openshift/kubernetes-apiserver v0.0.0-20201110074854-ee87de0d9d20/go.mod h1:FreAq0bJ2vtZFj9Ago/X0oNGC51GfubKK/ViOKfVAOA=
 github.com/openshift/kubernetes-client-go v0.0.0-20201104094117-806c7d66cfea h1:MY3sLcj2kfsjN36hEs0736bcyNFdUAOQLHXNL9u3+bc=
 github.com/openshift/kubernetes-client-go v0.0.0-20201104094117-806c7d66cfea/go.mod h1:S5wPhCqyDNAlzM9CnEdgTGV4OqhsW3jGO1UM1epwfJA=
 github.com/openshift/library-go v0.0.0-20201104144938-58b60c8e9aca h1:U51icmL2eTDp3BhQfO/XoflpB8bToOBJkcbWqqEh6zQ=

--- a/vendor/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/vendor/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -177,6 +177,10 @@ type DelegatingAuthenticationOptions struct {
 	// TolerateInClusterLookupFailure indicates failures to look up authentication configuration from the cluster configmap should not be fatal.
 	// Setting this can result in an authenticator that will reject all requests.
 	TolerateInClusterLookupFailure bool
+
+	// ClientTimeout specifies a time limit for requests made by the authorization webhook client.
+	// The default value is set to 10 seconds.
+	ClientTimeout time.Duration
 }
 
 func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
@@ -189,7 +193,13 @@ func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
 			GroupHeaders:        []string{"x-remote-group"},
 			ExtraHeaderPrefixes: []string{"x-remote-extra-"},
 		},
+		ClientTimeout: 10 * time.Second,
 	}
+}
+
+// WithClientTimeout sets the given timeout for the authentication webhook client.
+func (s *DelegatingAuthenticationOptions) WithClientTimeout(timeout time.Duration) {
+	s.ClientTimeout = timeout
 }
 
 func (s *DelegatingAuthenticationOptions) Validate() []error {
@@ -377,6 +387,7 @@ func (s *DelegatingAuthenticationOptions) getClient() (kubernetes.Interface, err
 	// set high qps/burst limits since this will effectively limit API server responsiveness
 	clientConfig.QPS = 200
 	clientConfig.Burst = 400
+	clientConfig.Timeout = s.ClientTimeout
 
 	return kubernetes.NewForConfig(clientConfig)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -461,7 +461,7 @@ k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
 k8s.io/apimachinery/third_party/forked/golang/reflect
-# k8s.io/apiserver v0.19.2 => github.com/openshift/kubernetes-apiserver v0.0.0-20201019143247-401ead4ea686
+# k8s.io/apiserver v0.19.2 => github.com/openshift/kubernetes-apiserver v0.0.0-20201110074854-ee87de0d9d20
 ## explicit
 k8s.io/apiserver/pkg/admission
 k8s.io/apiserver/pkg/admission/configuration
@@ -791,5 +791,5 @@ sigs.k8s.io/structured-merge-diff/v4/value
 sigs.k8s.io/yaml
 # github.com/RangelReale/osin => github.com/openshift/osin v1.0.1-0.20180202150137-2dc1b4316769
 # github.com/RangelReale/osincli => github.com/openshift/osincli v0.0.0-20160924135400-fababb0555f2
-# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20201019143247-401ead4ea686
+# k8s.io/apiserver => github.com/openshift/kubernetes-apiserver v0.0.0-20201110074854-ee87de0d9d20
 # k8s.io/client-go => github.com/openshift/kubernetes-client-go v0.0.0-20201104094117-806c7d66cfea


### PR DESCRIPTION
picks up https://github.com/openshift/kubernetes-apiserver/pull/19 which sets a default timeout for `TokenReview` client that is used by the webhook authenticator