### PR TITLE
base64-encode usernames when they contain ':' or '/'

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/authentication/user"
@@ -62,9 +64,10 @@ type DefaultUserIdentityInfo struct {
 
 // NewDefaultUserIdentityInfo returns a DefaultUserIdentityInfo with a non-nil Extra component
 func NewDefaultUserIdentityInfo(providerName, providerUserName string) *DefaultUserIdentityInfo {
+	userName := urlEncodeIfNecessary(providerUserName)
 	return &DefaultUserIdentityInfo{
 		ProviderName:     providerName,
-		ProviderUserName: providerUserName,
+		ProviderUserName: userName,
 		Extra:            map[string]string{},
 	}
 }
@@ -83,6 +86,13 @@ func (i *DefaultUserIdentityInfo) GetProviderUserName() string {
 
 func (i *DefaultUserIdentityInfo) GetExtra() map[string]string {
 	return i.Extra
+}
+
+func urlEncodeIfNecessary(s string) string {
+	if strings.ContainsAny(s, ":/") {
+		return "b64:" + base64.RawStdEncoding.EncodeToString([]byte(s))
+	}
+	return s
 }
 
 // ProviderInfo represents display information for an oauth identity provider.  This is used by the


### PR DESCRIPTION
This PR depends on oauth-apiserver changes to allow such usernames: https://github.com/openshift/oauth-apiserver/pull/47

Implements: https://github.com/openshift/enhancements/pull/590

closes https://github.com/openshift/oauth-server/issues/33

Some reference objects to see what we're dealing with (no 'preferred_username' set):
```yaml
apiVersion: user.openshift.io/v1
groups: null
identities:
- keycloak-jrm7v:b64:cG9rdXM6Om1pbGFuOi9va3VzL2xvbA
kind: User
metadata:
  name: b64:cG9rdXM6Om1pbGFuOi9va3VzL2xvbA
  uid: <--->

---
apiVersion: user.openshift.io/v1
kind: Identity
metadata:
  name: keycloak-jrm7v:b64:cG9rdXM6Om1pbGFuOi9va3VzL2xvbA
providerName: keycloak-test-e2e-test-authentication-operator-jrm7v
providerUserName: b64:cG9rdXM6Om1pbGFuOi9va3VzL2xvbA
user:
  name: b64:cG9rdXM6Om1pbGFuOi9va3VzL2xvbA
  uid: <--->
```