### PR TITLE
 AUTH-66: turn on audit on oauth-server with PW-based flow

### DIFF
--- a/cmd/oauth-server/main.go
+++ b/cmd/oauth-server/main.go
@@ -54,7 +54,7 @@ func NewOpenshiftIntegratedOAuthServerCommand(stopCh <-chan struct{}) *cobra.Com
 		},
 	}
 
-	startOsin := openshift_integrated_oauth_server.NewOsinServer(os.Stdout, os.Stderr, stopCh)
+	startOsin := openshift_integrated_oauth_server.NewOsinServerCommand(os.Stdout, os.Stderr, stopCh)
 	cmd.AddCommand(startOsin)
 
 	return cmd

--- a/pkg/audit/annotation.go
+++ b/pkg/audit/annotation.go
@@ -1,0 +1,43 @@
+package audit
+
+import (
+	"net/http"
+
+	kaudit "k8s.io/apiserver/pkg/audit"
+)
+
+// Decision is made with regards to authentication.
+type Decision string
+
+const (
+	// UsernameAnnotation is an annotation key for the username used for audit
+	// events.
+	UsernameAnnotation = "authentication.openshift.io/username"
+	// DecisionAnnotation is an annotation key for the authentication decision
+	// used for audit events.
+	DecisionAnnotation = "authentication.openshift.io/decision"
+
+	// AllowDecision is logged on a successful authentication.
+	AllowDecision Decision = "allow"
+	// DenyDecision is logged on an unsuccessful authentication attempt.
+	DenyDecision Decision = "deny"
+	// ErrorDecision is logged on errors that might not relate to the
+	// authentication itself.
+	ErrorDecision Decision = "error"
+)
+
+// AddDecisionAnnotation adds an authentication decision to the audit event. It
+// is used at best at last. So after the last identity provider gets checked as
+// if the first fails, and the last succeeds, you can't change the decision
+// anymore.
+func AddDecisionAnnotation(req *http.Request, decision Decision) {
+	kaudit.AddAuditAnnotation(req.Context(), DecisionAnnotation, string(decision))
+}
+
+// AddUsernameAnnotation adds the username that attempts to authenticate to the
+// audit event. It is used at best at the moment we parse the username. It can't
+// be handled down through an authenticator.Response as this one get erased on
+// `!ok` or `err != nil` case.
+func AddUsernameAnnotation(req *http.Request, username string) {
+	kaudit.AddAuditAnnotation(req.Context(), UsernameAnnotation, username)
+}

--- a/pkg/audit/annotation_test.go
+++ b/pkg/audit/annotation_test.go
@@ -1,0 +1,118 @@
+package audit_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	apiaudit "k8s.io/apiserver/pkg/apis/audit"
+	kaudit "k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/openshift/oauth-server/pkg/audit"
+)
+
+func verifyAnnotations(t *testing.T, req *http.Request, want map[string]string) {
+	ev, err := kaudit.NewEventFromRequest(
+		req, time.Now(),
+		apiaudit.LevelRequestResponse,
+		&authorizer.AttributesRecord{},
+	)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ev.Annotations) == 0 {
+		t.Error(errors.New("ev.Annotations is empty"))
+	}
+
+	for k, v := range want {
+		if ea, ok := ev.Annotations[k]; !ok || ea != v {
+			t.Error(fmt.Errorf("have: %s, want: %s", ea, v))
+		}
+	}
+}
+
+func TestAddUsername(t *testing.T) {
+	for _, tt := range [...]struct {
+		name string
+		have []string
+		want map[string]string
+	}{
+		{
+			name: "should annotate the username",
+			have: []string{"kubeadmin"},
+			want: map[string]string{
+				audit.UsernameAnnotation: "kubeadmin",
+			},
+		},
+		{
+			name: "should annotate the first given username",
+			have: []string{"system:unauthenticated", "kubeadmin"},
+			want: map[string]string{
+				audit.UsernameAnnotation: "system:unauthenticated",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := mustShallowRequestWithAnnotations(t)
+			for _, username := range tt.have {
+				audit.AddUsernameAnnotation(req, username)
+			}
+
+			verifyAnnotations(t, req, tt.want)
+		})
+	}
+}
+
+func decision(d audit.Decision) map[string]string {
+	return map[string]string{
+		audit.DecisionAnnotation: string(d),
+	}
+}
+
+func decisions(a ...audit.Decision) []audit.Decision {
+	return a
+}
+
+func TestAddDecision(t *testing.T) {
+	var tests = []struct {
+		name string
+		have []audit.Decision
+		want map[string]string
+	}{
+		{
+			name: "should add 'allow' to decision in audit annotation",
+			have: decisions(audit.AllowDecision),
+			want: decision(audit.AllowDecision),
+		},
+		{
+			name: "should add 'deny' to decision in audit annotation",
+			have: decisions(audit.DenyDecision),
+			want: decision(audit.DenyDecision),
+		},
+		{
+			name: "should add 'error' to decision in audit annotation",
+			have: decisions(audit.ErrorDecision),
+			want: decision(audit.ErrorDecision),
+		},
+		{
+			name: "should keep the first decision",
+			have: decisions(audit.DenyDecision, audit.AllowDecision),
+			want: decision(audit.DenyDecision),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := mustShallowRequestWithAnnotations(t)
+			for _, decision := range tt.have {
+				audit.AddDecisionAnnotation(req, decision)
+			}
+
+			verifyAnnotations(t, req, tt.want)
+		})
+	}
+}

--- a/pkg/audit/authreq.go
+++ b/pkg/audit/authreq.go
@@ -1,0 +1,39 @@
+package audit
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+// AuthenticatorFunc is a Function that satisfies the authenticator.Request
+// interface.
+type AuthenticatorFunc func(*http.Request) (*authenticator.Response, bool, error)
+
+var _ authenticator.Request = (*AuthenticatorFunc)(nil)
+
+// AuthenticateRequest makes the func satisfy the authenticator.Request interface.
+func (f AuthenticatorFunc) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+	return f(req)
+}
+
+// AuthenticatorRequestWithAuditDecision annotates the audit log with the final decision of the
+// union of authenticator.Requests. We can have several authenticator.Requesters hidden behind one
+// and unified with union. If we set the decision on anything except the last, we will get a
+// potentially wrong decision.
+func AuthenticatorRequestWithAuditDecision(authReq authenticator.Request) authenticator.Request {
+	return AuthenticatorFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		res, ok, err := authReq.AuthenticateRequest(req)
+
+		switch {
+		case err != nil:
+			AddDecisionAnnotation(req, ErrorDecision)
+		case !ok:
+			AddDecisionAnnotation(req, DenyDecision)
+		case ok:
+			AddDecisionAnnotation(req, AllowDecision)
+		}
+
+		return res, ok, err
+	})
+}

--- a/pkg/audit/authreq_test.go
+++ b/pkg/audit/authreq_test.go
@@ -1,0 +1,78 @@
+package audit_test
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/openshift/oauth-server/pkg/audit"
+	kaudit "k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authentication/authenticator"
+)
+
+// mustShallowRequestWithAnnotations could be extended with more features in the
+// future and renamed to mustRequest. Currently it is just a template for a
+// request with some URL and annotations context.
+func mustShallowRequestWithAnnotations(t *testing.T) *http.Request {
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"https://oauth-server.openshift.com/authn",
+		nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return req.WithContext(kaudit.WithAuditAnnotations(req.Context()))
+}
+
+func makeAuthReq(res *authenticator.Response, ok bool, err error) authenticator.Request {
+	return audit.AuthenticatorFunc(func(_ *http.Request) (*authenticator.Response, bool, error) {
+		return res, ok, err
+	})
+}
+
+func TestAuthenticationRequestWithAuditDecision(t *testing.T) {
+	for _, tt := range [...]struct {
+		name string
+		have authenticator.Request
+		want map[string]string
+	}{
+		{
+			name: "should audit allow decision",
+			have: makeAuthReq(nil, true, nil),
+			want: map[string]string{
+				audit.DecisionAnnotation: string(audit.AllowDecision),
+			},
+		},
+		{
+			name: "should audit deny decision",
+			have: makeAuthReq(nil, false, nil),
+			want: map[string]string{
+				audit.DecisionAnnotation: string(audit.DenyDecision),
+			},
+		},
+		{
+			name: "should audit error decision",
+			have: makeAuthReq(nil, false, errors.New("expected error")),
+			want: map[string]string{
+				audit.DecisionAnnotation: string(audit.ErrorDecision),
+			},
+		},
+		{
+			name: "ambiguous authenticator both allowing and erroring",
+			have: makeAuthReq(nil, true, errors.New("expected error")),
+			want: map[string]string{
+				audit.DecisionAnnotation: string(audit.ErrorDecision),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			authReq := audit.AuthenticatorRequestWithAuditDecision(tt.have)
+			req := mustShallowRequestWithAnnotations(t)
+
+			_, _, _ = authReq.AuthenticateRequest(req)
+			verifyAnnotations(t, req, tt.want)
+		})
+	}
+}

--- a/pkg/audit/validate.go
+++ b/pkg/audit/validate.go
@@ -1,0 +1,35 @@
+package audit
+
+import (
+	"errors"
+	"fmt"
+
+	"k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit/policy"
+)
+
+var (
+	// ErrNoPolicyFile is returned, when no path to a policy has been given.
+	ErrNoPolicyFile = errors.New("no policy file specified")
+)
+
+// Validate reads the given file path as policy file and rejects every level
+// of audit logging that is more verbose than metadata.
+func Validate(policyFile string) error {
+	if policyFile == "" {
+		return ErrNoPolicyFile
+	}
+
+	p, err := policy.LoadPolicyFromFile(policyFile)
+	if err != nil {
+		return fmt.Errorf("load audit policy file: %w", err)
+	}
+
+	for _, rule := range p.Rules {
+		if rule.Level != audit.LevelNone && rule.Level != audit.LevelMetadata {
+			return fmt.Errorf("policy level is beyond metadata: %s", rule.Level)
+		}
+	}
+
+	return nil
+}

--- a/pkg/audit/validate_test.go
+++ b/pkg/audit/validate_test.go
@@ -1,0 +1,59 @@
+package audit_test
+
+import (
+	"path"
+	"testing"
+
+	"github.com/openshift/oauth-server/pkg/audit"
+)
+
+func TestVerify(t *testing.T) {
+	rootFilePath := "../.."
+	testFilesPath := "test/files"
+
+	for _, tc := range [...]struct {
+		name      string
+		havePath  string
+		wantError bool
+	}{
+		{
+			name:      "metadata-policy should be valid",
+			havePath:  path.Join(rootFilePath, testFilesPath, "metadata-policy.yaml"),
+			wantError: false,
+		},
+		{
+			name:      "none-policy should be valid",
+			havePath:  path.Join(rootFilePath, testFilesPath, "none-policy.yaml"),
+			wantError: false,
+		},
+		{
+			name:      "none-metadata-policy should be valid",
+			havePath:  path.Join(rootFilePath, testFilesPath, "none-metadata-policy.yaml"),
+			wantError: false,
+		},
+		{
+			name:      "metadata-request-policy shouldn't be valid",
+			havePath:  path.Join(rootFilePath, testFilesPath, "metadata-request-policy.yaml"),
+			wantError: true,
+		},
+		{
+			name:      "request-policy shouldn't be valid",
+			havePath:  path.Join(rootFilePath, testFilesPath, "request-policy.yaml"),
+			wantError: true,
+		},
+		{
+			name:      "request-response-policy shouldn't be valid",
+			havePath:  path.Join(rootFilePath, testFilesPath, "request-response-policy.yaml"),
+			wantError: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := audit.Validate(tc.havePath)
+			haveError := err != nil
+
+			if haveError != tc.wantError {
+				t.Errorf("wantError: %t, haveError: %s", tc.wantError, err)
+			}
+		})
+	}
+}

--- a/pkg/groupmapper/groupmapper.go
+++ b/pkg/groupmapper/groupmapper.go
@@ -189,6 +189,10 @@ func (m *UserGroupsMapper) addUserToGroup(idpName, username, group string) error
 		return err
 	}
 
+	if updatedGroup.Annotations == nil {
+		updatedGroup.Annotations = map[string]string{}
+	}
+
 	var onlyAddAnnotation bool
 	for _, u := range updatedGroup.Users {
 		if u == username {

--- a/pkg/groupmapper/groupmapper_test.go
+++ b/pkg/groupmapper/groupmapper_test.go
@@ -288,6 +288,20 @@ func TestUserGroupsMapper_addUserToGroup(t *testing.T) {
 			expectEvent:   true,
 		},
 		{
+			name:          "group with no annotations yet - user missng",
+			username:      "user2",
+			group:         removeGroupAnnotations(createGroupWithUsers(testGroupName, "user1", "user2", "user3", "user4")),
+			expectedGroup: removeGeneratedKeyFromGroup(createGroupWithUsers(testGroupName, "user1", "user2", "user3", "user4")),
+			expectEvent:   true,
+		},
+		{
+			name:          "group with no annotations yet - user present",
+			username:      "user2",
+			group:         removeGroupAnnotations(createGroupWithUsers(testGroupName, "user1", "user3", "user4")),
+			expectedGroup: removeGeneratedKeyFromGroup(createGroupWithUsers(testGroupName, "user1", "user3", "user4", "user2")),
+			expectEvent:   true,
+		},
+		{
 			name:          "user already in group",
 			username:      "user3",
 			group:         createGroupWithUsers(testGroupName, "user1", "user2", "user3", "user4"),
@@ -375,6 +389,11 @@ func removeGeneratedKeyFromGroup(g *userv1.Group) *userv1.Group {
 
 func removeSyncedKeyFromGroup(g *userv1.Group, idpName string) *userv1.Group {
 	delete(g.Annotations, fmt.Sprintf(groupSyncedKeyFmt, idpName))
+	return g
+}
+
+func removeGroupAnnotations(g *userv1.Group) *userv1.Group {
+	g.Annotations = nil
 	return g
 }
 

--- a/pkg/oauth/registry/registry_test.go
+++ b/pkg/oauth/registry/registry_test.go
@@ -283,7 +283,13 @@ func TestRegistryAndServer(t *testing.T) {
 		}
 		fakeOAuthClient := oauthfake.NewSimpleClientset(objs...)
 		fakeTokenReviewClient := kubefake.NewSimpleClientset()
-		storage := registrystorage.New(fakeOAuthClient.OauthV1().OAuthAccessTokens(), fakeOAuthClient.OauthV1().OAuthAuthorizeTokens(), fakeOAuthClient.OauthV1().OAuthClients(), fakeTokenReviewClient.AuthenticationV1().TokenReviews(), 0)
+		storage := registrystorage.New(
+			fakeOAuthClient.OauthV1().OAuthAccessTokens(),
+			fakeOAuthClient.OauthV1().OAuthAuthorizeTokens(),
+			fakeOAuthClient.OauthV1().OAuthClients(),
+			fakeTokenReviewClient.AuthenticationV1().TokenReviews(),
+			0,
+		)
 		config := osinserver.NewDefaultServerConfig()
 
 		h.AuthorizeHandler = osinserver.AuthorizeHandlers{

--- a/pkg/oauthserver/annotation_test.go
+++ b/pkg/oauthserver/annotation_test.go
@@ -1,0 +1,61 @@
+package oauthserver_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	apiaudit "k8s.io/apiserver/pkg/apis/audit"
+	kaudit "k8s.io/apiserver/pkg/audit"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/openshift/oauth-server/pkg/audit"
+)
+
+func withDecisionAnnotation(want string) func(*testing.T, map[string]string) {
+	return func(t *testing.T, ano map[string]string) {
+		if have, ok := ano[audit.DecisionAnnotation]; !ok || want != have {
+			t.Error(fmt.Errorf(
+				"want: %s for decision, have: %s for decision",
+				want, have,
+			))
+		}
+	}
+}
+
+func withUsernameAnnotation(want string) func(*testing.T, map[string]string) {
+	return func(t *testing.T, ano map[string]string) {
+		have, ok := ano[audit.UsernameAnnotation]
+		valueExpected := len(want) > 0
+
+		if !ok && valueExpected || want != have {
+			t.Error(fmt.Errorf(
+				"want: '%s' for username, have: '%s' for username and ok is %t",
+				want, have, ok,
+			))
+		}
+	}
+}
+
+type annotationChecker func(*testing.T, map[string]string)
+
+func verifyAnnotations(t *testing.T, req *http.Request, checker []annotationChecker) {
+	ev, err := kaudit.NewEventFromRequest(
+		req, time.Now(),
+		apiaudit.LevelRequestResponse,
+		&authorizer.AttributesRecord{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(ev.Annotations) == 0 {
+		t.Error(errors.New("ev.Annotations is empty"))
+	}
+
+	for _, check := range checker {
+		check(t, ev.Annotations)
+	}
+}

--- a/pkg/oauthserver/auth_test.go
+++ b/pkg/oauthserver/auth_test.go
@@ -1,0 +1,89 @@
+package oauthserver_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/openshift/oauth-server/pkg/audit"
+
+	kaudit "k8s.io/apiserver/pkg/audit"
+)
+
+// TestWithOAuth is currently only testing auditing and therefore heavily mocked.
+// It is encouraged to reduce the mocking and test more parts of WithOAuth.
+func TestWithOAuth(t *testing.T) {
+	h := setup(t)
+
+	for _, tc := range [...]struct {
+		name     string
+		given    *http.Request
+		expected []annotationChecker
+	}{
+		{
+			name: "should audit success for bootstrap user (kubeadmin) and good password",
+			given: func() *http.Request {
+				req := httptest.NewRequest(
+					http.MethodGet,
+					authorizeURL,
+					nil,
+				)
+				req = req.WithContext(kaudit.WithAuditAnnotations(req.Context()))
+
+				withAuth(req, "kubeadmin", testPassword)
+				return req
+			}(),
+			expected: []annotationChecker{
+				withUsernameAnnotation("kubeadmin"),
+				withDecisionAnnotation(string(audit.AllowDecision)),
+			},
+		},
+		{
+			name: "should audit deny by default",
+			given: func() *http.Request {
+				req := httptest.NewRequest(
+					http.MethodGet,
+					authorizeURL,
+					nil,
+				)
+				req = req.WithContext(kaudit.WithAuditAnnotations(req.Context()))
+
+				return req
+			}(),
+			expected: []annotationChecker{
+				withUsernameAnnotation(""),
+				withDecisionAnnotation(string(audit.DenyDecision)),
+			},
+		},
+		{
+			name: "should audit deny on kubeadmin user with wrong password",
+			given: func() *http.Request {
+				req := httptest.NewRequest(
+					http.MethodGet,
+					authorizeURL,
+					nil,
+				)
+				req = req.WithContext(kaudit.WithAuditAnnotations(req.Context()))
+
+				withAuth(req, "kubeadmin", "random-non-sense-non-sense")
+				return req
+			}(),
+			expected: []annotationChecker{
+				withUsernameAnnotation("kubeadmin"),
+				withDecisionAnnotation(string(audit.DenyDecision)),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, tc.given)
+
+			res := rec.Result()
+			if res.StatusCode != http.StatusFound {
+				t.Error(res)
+			}
+
+			verifyAnnotations(t, tc.given, tc.expected)
+		})
+	}
+}

--- a/pkg/oauthserver/setup_test.go
+++ b/pkg/oauthserver/setup_test.go
@@ -1,0 +1,131 @@
+package oauthserver_test
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakekube "k8s.io/client-go/kubernetes/fake"
+
+	oauthv1 "github.com/openshift/api/oauth/v1"
+	osinv1 "github.com/openshift/api/osin/v1"
+	fakeoauthclient "github.com/openshift/client-go/oauth/clientset/versioned/fake"
+	typedv1 "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	fakeuserclient "github.com/openshift/client-go/user/clientset/versioned/fake"
+	userinformer "github.com/openshift/client-go/user/informers/externalversions"
+	bootstrap "github.com/openshift/library-go/pkg/authentication/bootstrapauthenticator"
+
+	"github.com/openshift/oauth-server/pkg/config"
+	"github.com/openshift/oauth-server/pkg/oauthserver"
+	"github.com/openshift/oauth-server/pkg/userregistry/identitymapper"
+)
+
+const (
+	testPassword = "testpasswordxtestpasswordx" // must have at least len 23
+
+	testClientName = "my_client"
+)
+
+var authorizeURL = "/oauth/authorize?client_id=" + testClientName +
+	"&response_type=code"
+
+func withAuth(req *http.Request, username, password string) {
+	req.SetBasicAuth(username, password)
+}
+
+type mockBootstrapUser func() (*bootstrap.BootstrapUserData, bool, error)
+
+var _ bootstrap.BootstrapUserDataGetter = (*mockBootstrapUser)(nil)
+
+func (b mockBootstrapUser) IsEnabled() (bool, error) {
+	return true, nil
+}
+
+func (b mockBootstrapUser) Get() (*bootstrap.BootstrapUserData, bool, error) {
+	return b()
+}
+
+func kubeAdmin(t *testing.T, passwordHash []byte, auth bool, err error) mockBootstrapUser {
+	return func() (*bootstrap.BootstrapUserData, bool, error) {
+		hash, err := bcrypt.GenerateFromPassword(passwordHash, bcrypt.DefaultCost)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &bootstrap.BootstrapUserData{
+			PasswordHash: hash,
+			UID:          "kubeadmin-user-id",
+		}, auth, err
+	}
+}
+
+func setup(t *testing.T) http.Handler {
+	kubeClient := fakekube.NewSimpleClientset()
+	oauthClient := goodClientRegistry(
+		testClientName,
+		[]string{"myredirect"},
+		[]string{"myscope1", "myscope2"},
+	)
+	kubeAdminIDP := kubeAdmin(t, []byte(testPassword), true, nil)
+	informer := userinformer.NewSharedInformerFactory(
+		fakeuserclient.NewSimpleClientset(),
+		time.Second*30,
+	)
+
+	opts := osinv1.OAuthConfig{
+		LoginURL: "/oauth/login",
+		IdentityProviders: []osinv1.IdentityProvider{
+			{
+				Name:            bootstrap.BootstrapUser, // aka kube:admin
+				UseAsChallenger: false,
+				UseAsLogin:      false,
+				MappingMethod:   string(identitymapper.MappingMethodClaim), // irrelevant, but needs to be valid
+				Provider: runtime.RawExtension{
+					Object: &config.BootstrapIdentityProvider{},
+				},
+			},
+		},
+		GrantConfig: osinv1.GrantConfig{
+			Method: osinv1.GrantHandlerAuto,
+		},
+	}
+
+	oauthServerConfig := oauthserver.OAuthServerConfig{
+		ExtraOAuthConfig: oauthserver.ExtraOAuthConfig{
+			KubeClient:              kubeClient,
+			OAuthClientClient:       oauthClient,
+			Options:                 opts,
+			BootstrapUserDataGetter: kubeAdminIDP,
+			GroupInformer:           informer.User().V1().Groups(),
+		},
+	}
+
+	h, err := oauthServerConfig.WithOAuth(http.NewServeMux())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return h
+}
+
+func goodClientRegistry(
+	clientID string,
+	redirectURIs []string,
+	literalScopes []string,
+) typedv1.OAuthClientInterface {
+	client := &oauthv1.OAuthClient{
+		ObjectMeta:   metav1.ObjectMeta{Name: clientID},
+		Secret:       "mysecret",
+		RedirectURIs: redirectURIs,
+	}
+	if len(literalScopes) > 0 {
+		client.ScopeRestrictions = []oauthv1.ScopeRestriction{{ExactValues: literalScopes}}
+	}
+	fakeOAuthClient := fakeoauthclient.NewSimpleClientset(client)
+
+	return fakeOAuthClient.OauthV1().OAuthClients()
+}

--- a/pkg/osinserver/registrystorage/storage.go
+++ b/pkg/osinserver/registrystorage/storage.go
@@ -35,7 +35,13 @@ type storage struct {
 	tokentimeout   int32
 }
 
-func New(access oauthclient.OAuthAccessTokenInterface, authorize oauthclient.OAuthAuthorizeTokenInterface, client api.OAuthClientGetter, tokenReview authenticationv1client.TokenReviewInterface, tokentimeout int32) osin.Storage {
+func New(
+	access oauthclient.OAuthAccessTokenInterface,
+	authorize oauthclient.OAuthAuthorizeTokenInterface,
+	client api.OAuthClientGetter,
+	tokenReview authenticationv1client.TokenReviewInterface,
+	tokentimeout int32,
+) osin.Storage {
 	return &storage{
 		accesstoken:    access,
 		authorizetoken: authorize,

--- a/pkg/server/grant/grant_test.go
+++ b/pkg/server/grant/grant_test.go
@@ -46,7 +46,6 @@ func emptyClientRegistry() api.OAuthClientGetter {
 
 func goodClientRegistry(clientID string, redirectURIs []string, literalScopes []string) api.OAuthClientGetter {
 	client := &oapi.OAuthClient{ObjectMeta: metav1.ObjectMeta{Name: clientID}, Secret: "mysecret", RedirectURIs: redirectURIs}
-	client.Name = clientID
 	if len(literalScopes) > 0 {
 		client.ScopeRestrictions = []oapi.ScopeRestriction{{ExactValues: literalScopes}}
 	}

--- a/test/files/metadata-policy.yaml
+++ b/test/files/metadata-policy.yaml
@@ -1,0 +1,4 @@
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+- level: Metadata

--- a/test/files/metadata-request-policy.yaml
+++ b/test/files/metadata-request-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: audit.k8s.io/v1 # This is required.
+kind: Policy
+rules:
+- level: Metadata
+  resources:
+  - group: ""
+    resources: ["pods/log", "pods/status"]
+- level: Request
+  resources:
+  - group: ""
+    resources: ["secrets", "configmaps"]

--- a/test/files/none-metadata-policy.yaml
+++ b/test/files/none-metadata-policy.yaml
@@ -1,0 +1,11 @@
+apiVersion: audit.k8s.io/v1 # This is required.
+kind: Policy
+rules:
+- level: None
+  resources:
+  - group: ""
+    resources: ["secrets", "configmaps"]
+- level: Metadata
+  resources:
+  - group: ""
+    resources: ["pods/log", "pods/status"]

--- a/test/files/none-policy.yaml
+++ b/test/files/none-policy.yaml
@@ -1,0 +1,3 @@
+apiVersion: audit.k8s.io/v1
+rules:
+- level: None

--- a/test/files/request-policy.yaml
+++ b/test/files/request-policy.yaml
@@ -1,0 +1,3 @@
+apiVersion: audit.k8s.io/v1
+rules:
+- level: Request

--- a/test/files/request-response-policy.yaml
+++ b/test/files/request-response-policy.yaml
@@ -1,0 +1,3 @@
+apiVersion: audit.k8s.io/v1
+rules:
+- level: RequestResponse


### PR DESCRIPTION
## What

Enable audit for PW-based flow.

## Why

This is part of a bigger effort to enable audit logging for authentication events for the sake of compliance.

## How

- Enabling by passing in configuration through options
- Using k8s.io/apiserver middleware