### PR TITLE
Bug 2020625: oidc: allocate claims slice to 0 len to prevent empty groups

### DIFF
--- a/pkg/oauth/external/openid/openid.go
+++ b/pkg/oauth/external/openid/openid.go
@@ -240,7 +240,7 @@ func getArrayOrStringClaimValue(data map[string]interface{}, claims ...string) (
 		}
 		switch valTyped := val.(type) {
 		case []interface{}:
-			ret := make([]string, len(valTyped))
+			ret := make([]string, 0, len(valTyped))
 			for _, s := range valTyped {
 				ret = append(ret, s.(string))
 			}


### PR DESCRIPTION
/assign @ibihim 
cc @s-urbaniak 