### PR TITLE
Bug 2086465: External OAuth: create audit logs for auth events

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,0 +1,51 @@
+package api
+
+// AuthorizationDeniedError must be raised by external identity checkers to
+// signal that even though authentication was successful, futher rules denied
+// access.
+//
+// Calls to Error() will be passed directly to the wrapped error.
+type AuthorizationDeniedError struct {
+	identity UserIdentityInfo
+	error
+}
+
+// NewAuthorizationDeniedError wraps the given error in an
+// AuthorizationFailedError type, which exposes the given identity.
+func NewAuthorizationDeniedError(identity UserIdentityInfo, err error) AuthorizationDeniedError {
+	return AuthorizationDeniedError{
+		identity: identity,
+		error:    err,
+	}
+}
+
+// Identity returns identity information relative to a denied access attempt.
+func (e AuthorizationDeniedError) Identity() UserIdentityInfo { return e.identity }
+
+// Unwrap returns the underlying error to satisfy errors.As() and errors.Is().
+func (e AuthorizationDeniedError) Unwrap() error { return e.error }
+
+// AuthorizationFailedError can be raised by external identity checkers to
+// return information about identity, when a runtime error occurs while
+// identity information is already available.
+//
+// Calls to Error() will be passed directly to the wrapped error.
+type AuthorizationFailedError struct {
+	identity UserIdentityInfo
+	error
+}
+
+// NewAuthorizationFailedError wraps the given error in an
+// AuthorizationFailedError type, which exposes the given identity.
+func NewAuthorizationFailedError(identity UserIdentityInfo, err error) AuthorizationFailedError {
+	return AuthorizationFailedError{
+		identity: identity,
+		error:    err,
+	}
+}
+
+// Identity returns identity information relative to a failed access attempt.
+func (e AuthorizationFailedError) Identity() UserIdentityInfo { return e.identity }
+
+// Unwrap returns the underlying error to satisfy errors.As() and errors.Is().
+func (e AuthorizationFailedError) Unwrap() error { return e.error }

--- a/pkg/oauth/external/github/github_test.go
+++ b/pkg/oauth/external/github/github_test.go
@@ -1,0 +1,205 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/RangelReale/osincli"
+	"github.com/openshift/oauth-server/pkg/api"
+)
+
+func TestGetUserIdentity(t *testing.T) {
+	newGithubIdentityProvider := func(username string, orgs []string) http.RoundTripper {
+		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			body := new(bytes.Buffer)
+
+			switch req.URL.Path {
+			case "/user":
+				if err := json.NewEncoder(body).Encode(struct {
+					ID                 uint64
+					Login, Email, Name string
+				}{
+					ID:    12345,
+					Login: username,
+					Email: "user@example.com",
+				}); err != nil {
+					panic(err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     http.StatusText(http.StatusOK),
+					Body:       io.NopCloser(body),
+				}, nil
+
+			case "/user/orgs":
+				type ghOrg struct {
+					ID    uint64
+					Login string
+				}
+				ghOrgs := make([]ghOrg, len(orgs))
+				for i := range orgs {
+					ghOrgs[i] = ghOrg{
+						ID:    999,
+						Login: orgs[i],
+					}
+
+				}
+
+				if err := json.NewEncoder(body).Encode(ghOrgs); err != nil {
+					panic(err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     http.StatusText(http.StatusOK),
+					Body:       io.NopCloser(body),
+				}, nil
+
+			default:
+				return nil, fmt.Errorf("this fixture does not serve the requested path: %s", req.URL.Path)
+			}
+		})
+	}
+
+	type checkFunc func(api.UserIdentityInfo, error) error
+	hasUsername := func(want string) checkFunc {
+		return func(userIdentityInfo api.UserIdentityInfo, _ error) error {
+			if have := userIdentityInfo.GetProviderPreferredUserName(); want != have {
+				return fmt.Errorf("expected username %q, got %q", want, have)
+			}
+			return nil
+		}
+	}
+	hasUsernameInError := func(want string) checkFunc {
+		return func(_ api.UserIdentityInfo, err error) error {
+			var userIdentityInfo api.UserIdentityInfo
+
+			var denied api.AuthorizationDeniedError
+			if errors.As(err, &denied) {
+				userIdentityInfo = denied.Identity()
+			}
+
+			var failed api.AuthorizationFailedError
+			if errors.As(err, &failed) {
+				userIdentityInfo = failed.Identity()
+			}
+
+			if have := userIdentityInfo.GetProviderPreferredUserName(); want != have {
+				return fmt.Errorf("expected username %q, got %q", want, have)
+			}
+			return nil
+		}
+	}
+	isAllowed := func(_ api.UserIdentityInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("unexpected error: %v", err)
+		}
+		return nil
+	}
+	isDenied := func(_ api.UserIdentityInfo, err error) error {
+		if err == nil {
+			return fmt.Errorf("expected authorization error, got nil")
+		}
+		var authError api.AuthorizationDeniedError
+		if !errors.As(err, &authError) {
+			return fmt.Errorf("expected authorization error, got %v", err)
+		}
+		return nil
+	}
+
+	for _, tc := range [...]struct {
+		name                 string
+		username             string
+		userOrganizations    []string
+		allowedOrganizations []string
+
+		checks []checkFunc
+	}{
+		{
+			name:     "ok",
+			username: "hello",
+			checks: []checkFunc{
+				isAllowed,
+				hasUsername("hello"),
+			},
+		},
+		{
+			name:                 "ok with organization check",
+			username:             "hello",
+			userOrganizations:    []string{"vip"},
+			allowedOrganizations: []string{"vip"},
+			checks: []checkFunc{
+				isAllowed,
+				hasUsername("hello"),
+			},
+		},
+		{
+			name:                 "ok with organization check, member of multiple",
+			username:             "hello",
+			userOrganizations:    []string{"openshift", "gophercloud", "vip", "kubernetes"},
+			allowedOrganizations: []string{"vip"},
+			checks: []checkFunc{
+				isAllowed,
+				hasUsername("hello"),
+			},
+		},
+		{
+			name:                 "ok with organization check, multiple allowed",
+			username:             "hello",
+			userOrganizations:    []string{"vip"},
+			allowedOrganizations: []string{"vip", "openshift", "kubernetes"},
+			checks: []checkFunc{
+				isAllowed,
+				hasUsername("hello"),
+			},
+		},
+		{
+			name:                 "denied, not in organization",
+			username:             "hello",
+			userOrganizations:    []string{"microsoft"},
+			allowedOrganizations: []string{"neovim"},
+			checks: []checkFunc{
+				isDenied,
+				hasUsernameInError("hello"),
+			},
+		},
+		{
+			name:                 "denied, not in any organization",
+			username:             "hello",
+			allowedOrganizations: []string{"vip"},
+			checks: []checkFunc{
+				isDenied,
+				hasUsernameInError("hello"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			userIdentityInfo, err := NewProvider(
+				"git-tub",
+				"my_client_id",
+				"my_client_secret",
+				"",
+				newGithubIdentityProvider(tc.username, tc.userOrganizations),
+				tc.allowedOrganizations,
+				nil,
+			).GetUserIdentity(&osincli.AccessData{})
+
+			for _, check := range tc.checks {
+				if e := check(userIdentityInfo, err); e != nil {
+					t.Error(e)
+				}
+			}
+		})
+	}
+
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (rt roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rt(req)
+}

--- a/pkg/oauth/external/gitlab/gitlab_oauth.go
+++ b/pkg/oauth/external/gitlab/gitlab_oauth.go
@@ -81,7 +81,7 @@ func (p *provider) NewConfig() (*osincli.ClientConfig, error) {
 func (p *provider) AddCustomParameters(req *osincli.AuthorizeRequest) {}
 
 // GetUserIdentity implements external/interfaces/Provider.GetUserIdentity
-func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, bool, error) {
+func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, error) {
 	req, _ := http.NewRequest("GET", p.userAPIURL, nil)
 	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", data.AccessToken))
 
@@ -91,23 +91,23 @@ func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdenti
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	userdata := gitlabUser{}
 	err = json.Unmarshal(body, &userdata)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	if userdata.ID == 0 {
-		return nil, false, errors.New("Could not retrieve GitLab id")
+		return nil, errors.New("Could not retrieve GitLab id")
 	}
 
 	identity := authapi.NewDefaultUserIdentityInfo(p.providerName, fmt.Sprintf("%d", userdata.ID))
@@ -122,5 +122,5 @@ func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdenti
 	}
 	klog.V(4).Infof("Got identity=%#v", identity)
 
-	return identity, true, nil
+	return identity, nil
 }

--- a/pkg/oauth/external/handler_test.go
+++ b/pkg/oauth/external/handler_test.go
@@ -2,20 +2,160 @@ package external
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/RangelReale/osincli"
+	"github.com/openshift/oauth-server/pkg/api"
 	"github.com/openshift/oauth-server/pkg/oauth/handlers"
 	"github.com/openshift/oauth-server/pkg/server/csrf"
+	auditapi "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 func TestHandler(t *testing.T) {
 	redirectors := new(handlers.AuthenticationRedirectors)
 	redirectors.Add("handler", &Handler{})
 	_ = handlers.NewUnionAuthenticationHandler(nil, redirectors, nil, nil)
+}
+
+func TestHandlerLogin(t *testing.T) {
+	t.Run("audit", func(t *testing.T) {
+		type checkFunc func(*auditapi.Event, authenticationHandler, *userIdentityMapper) error
+
+		eventHasUsername := func(want string) checkFunc {
+			return func(ev *auditapi.Event, _ authenticationHandler, _ *userIdentityMapper) error {
+				if have := ev.Annotations["authentication.openshift.io/username"]; want != have {
+					return fmt.Errorf("expected username %q, found %q", want, have)
+				}
+				return nil
+			}
+		}
+		eventHasDecision := func(want string) checkFunc {
+			return func(ev *auditapi.Event, _ authenticationHandler, _ *userIdentityMapper) error {
+				if have := ev.Annotations["authentication.openshift.io/decision"]; want != have {
+					return fmt.Errorf("expected decision %q, found %q", want, have)
+				}
+				return nil
+			}
+		}
+		isAuthorized := func(_ *auditapi.Event, h authenticationHandler, _ *userIdentityMapper) error {
+			if !h.success {
+				return fmt.Errorf("expected call to success handler did not happen")
+			}
+			if h.failure {
+				return fmt.Errorf("unexpected call to error handler")
+			}
+			return nil
+		}
+		isNotAuthorized := func(_ *auditapi.Event, h authenticationHandler, _ *userIdentityMapper) error {
+			if !h.failure {
+				return fmt.Errorf("expected call to error handler did not happen")
+			}
+			if h.success {
+				return fmt.Errorf("unexpected call to success handler")
+			}
+			return nil
+		}
+		mapperWasNotCalled := func(_ *auditapi.Event, _ authenticationHandler, m *userIdentityMapper) error {
+			if m.wasCalled {
+				return fmt.Errorf("the identity mapper was called upon unsuccessful auth")
+			}
+			return nil
+		}
+
+		for _, tc := range [...]struct {
+			name     string
+			username string
+			err      error
+			checks   []checkFunc
+		}{
+			{
+				name:     "authorized",
+				username: "boucle_d_or",
+				err:      nil,
+				checks: []checkFunc{
+					eventHasUsername("boucle_d_or"),
+					eventHasDecision("allow"),
+					isAuthorized,
+				},
+			},
+			{
+				name:     "error",
+				username: "boucle_d_or",
+				err:      fmt.Errorf("identity provider error"),
+				checks: []checkFunc{
+					eventHasDecision("error"),
+					isNotAuthorized,
+					mapperWasNotCalled,
+				},
+			},
+			{
+				name:     "unauthorized",
+				username: "boucle_d_or",
+				err: api.NewAuthorizationDeniedError(
+					api.NewDefaultUserIdentityInfo("testprovider", "boucle_d_or"),
+					errors.New("user not in group"),
+				),
+				checks: []checkFunc{
+					eventHasUsername("boucle_d_or"),
+					eventHasDecision("deny"),
+					isNotAuthorized,
+					mapperWasNotCalled,
+				},
+			},
+			{
+				name:     "error_with_username",
+				username: "boucle_d_or",
+				err: api.NewAuthorizationFailedError(
+					api.NewDefaultUserIdentityInfo("testprovider", "boucle_d_or"),
+					errors.New("user not in group"),
+				),
+				checks: []checkFunc{
+					eventHasUsername("boucle_d_or"),
+					eventHasDecision("error"),
+					isNotAuthorized,
+					mapperWasNotCalled,
+				},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				authHandler := new(authenticationHandler)
+				identityMapper := new(userIdentityMapper)
+				h := Handler{
+					provider: provider{
+						name:     "testprovider",
+						username: tc.username,
+						err:      tc.err,
+					},
+					mapper:       identityMapper,
+					success:      authHandler,
+					errorHandler: authHandler,
+				}
+
+				req := httptest.NewRequest(http.MethodPost, "https://auth.example.com/callback", nil)
+				req = req.WithContext(audit.WithAuditAnnotations(req.Context()))
+
+				h.login(httptest.NewRecorder(), req, nil, "state")
+
+				ev, err := audit.NewEventFromRequest(req, time.Time{}, "Request", authorizer.AttributesRecord{})
+				if err != nil {
+					t.Fatalf("unexpected error in retrieving the audit events: %v", err)
+				}
+
+				for _, check := range tc.checks {
+					if err := check(ev, *authHandler, identityMapper); err != nil {
+						t.Error(err)
+					}
+				}
+			})
+		}
+	})
 }
 
 func TestRedirectingStateValidCSRF(t *testing.T) {
@@ -148,4 +288,41 @@ func TestRedirectingStateError(t *testing.T) {
 	if err != inErr {
 		t.Errorf("Expected original error back, got %#v", err)
 	}
+}
+
+type provider struct {
+	name     string
+	username string
+	err      error
+	Provider
+}
+
+func (p provider) GetUserIdentity(*osincli.AccessData) (api.UserIdentityInfo, error) {
+	return &api.DefaultUserIdentityInfo{
+		ProviderName:     p.name,
+		ProviderUserName: p.username,
+	}, p.err
+}
+
+type userIdentityMapper struct {
+	wasCalled bool
+}
+
+func (m *userIdentityMapper) UserFor(identityInfo api.UserIdentityInfo) (user.Info, error) {
+	m.wasCalled = true
+	return &user.DefaultInfo{Name: identityInfo.GetProviderUserName()}, nil
+}
+
+type authenticationHandler struct {
+	success bool
+	failure bool
+}
+
+func (h *authenticationHandler) AuthenticationSucceeded(user.Info, string, http.ResponseWriter, *http.Request) (bool, error) {
+	h.success = true
+	return true, nil
+}
+func (h *authenticationHandler) AuthenticationError(error, http.ResponseWriter, *http.Request) (bool, error) {
+	h.failure = true
+	return true, nil
 }

--- a/pkg/oauth/external/interfaces.go
+++ b/pkg/oauth/external/interfaces.go
@@ -17,8 +17,9 @@ type Provider interface {
 	GetTransport() (http.RoundTripper, error)
 	// AddCustomParameters allows an external oauth provider to provide parameters that are extension to the spec.  Some providers require this.
 	AddCustomParameters(*osincli.AuthorizeRequest)
-	// GetUserIdentity takes the external oauth token information this and returns the user identity, isAuthenticated, and error
-	GetUserIdentity(*osincli.AccessData) (authapi.UserIdentityInfo, bool, error)
+	// GetUserIdentity takes the external oauth token information and returns the user identity or a non-nil error.
+	// When error is non-nil and the user identity is available, the returned error is of type AuthorizationDenialError or AuthorizationFailureError.
+	GetUserIdentity(*osincli.AccessData) (authapi.UserIdentityInfo, error)
 }
 
 // State handles generating and verifying the state parameter round-tripped to an external OAuth flow.


### PR DESCRIPTION
With this patch, authentication mediated by external identity providers
is logged in the audit trail. When available, the internal mapping of
the identity confirmed by the external identity provider is attached to
both successful and unsuccessful authentication events.

Implements [AUTH-70](https://issues.redhat.com/browse/AUTH-70)