### PR TITLE
AUTH-100: Add request header authn auditing

### DIFF
--- a/pkg/audit/annotation.go
+++ b/pkg/audit/annotation.go
@@ -39,5 +39,9 @@ func AddDecisionAnnotation(req *http.Request, decision Decision) {
 // be handled down through an authenticator.Response as this one get erased on
 // `!ok` or `err != nil` case.
 func AddUsernameAnnotation(req *http.Request, username string) {
+	if username == "" {
+		return
+	}
+
 	kaudit.AddAuditAnnotation(req.Context(), UsernameAnnotation, username)
 }

--- a/pkg/oauthserver/auth.go
+++ b/pkg/oauthserver/auth.go
@@ -627,7 +627,7 @@ func (c *OAuthServerConfig) getAuthenticationRequestHandlerWithAudit() (authenti
 		return authReq, err
 	}
 
-	return audit.AuthenticatorRequestWithAuditDecision(authReq), nil
+	return audit.AuthenticatorRequestWithAudit(authReq), nil
 }
 
 func (c *OAuthServerConfig) getAuthenticationRequestHandler() (authenticator.Request, error) {


### PR DESCRIPTION
## What

- Add audit logging to request header authentication, which is used in auth-proxy use cases.
- Add more audit logging in other areas as a catch-up.

## Why

Users want to have audit logging. A crucial flow is the request header flow.

For the catch-ups topics:
- Authentication happens in the HandleAccess case and is not audited.
- The optimistic authentication audit logging should handle all happy cases in general.