### PR TITLE
AUTH-70: Add audit logging to external provider

### DIFF
--- a/pkg/oauth/external/github/error.go
+++ b/pkg/oauth/external/github/error.go
@@ -1,0 +1,17 @@
+package github
+
+import "fmt"
+
+type authorizationError string
+
+func newAuthorizationErrorf(format string, args ...interface{}) authorizationError {
+	return authorizationError(fmt.Sprintf(format, args...))
+}
+
+func (err authorizationError) AuthorizationDenialReason() string {
+	return string(err)
+}
+
+func (err authorizationError) Error() string {
+	return string(err)
+}

--- a/pkg/oauth/external/github/error.go
+++ b/pkg/oauth/external/github/error.go
@@ -1,17 +1,65 @@
 package github
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
-type authorizationError string
+type authorizationError struct {
+	msg      string
+	username string
 
-func newAuthorizationErrorf(format string, args ...interface{}) authorizationError {
-	return authorizationError(fmt.Sprintf(format, args...))
+	wrapped error
 }
 
-func (err authorizationError) AuthorizationDenialReason() string {
-	return string(err)
+// NewAuthorizationErrorf creates an authorizationError that behaves like a
+// typical error and offers in addition the username that experienced the
+// authorization error.
+func NewAuthorizationErrorf(username, format string, args ...interface{}) error {
+	return &authorizationError{
+		// TODO@ibihim: resuse username in err msg and then reduce username as arg in use.
+		msg:      fmt.Sprintf(format, args...),
+		username: username,
+	}
 }
 
-func (err authorizationError) Error() string {
-	return string(err)
+// NewAuthorizationError creates an authorizationError that behaves like a
+// typical error, wraps the previous error and offers in addition the username
+// that experienced the authorization error.
+func NewAuthorizationError(username string, msg string, err error) error {
+	return &authorizationError{
+		username: username,
+		msg:      msg,
+		wrapped:  err,
+	}
+}
+
+// Username returns the Username that ran into the error.
+func (err *authorizationError) Username() string {
+	return err.username
+}
+
+// Error returns an error message.
+func (err *authorizationError) Error() string {
+	var builder strings.Builder
+
+	if err.username != "" {
+		builder.WriteString("user ")
+		builder.WriteString(err.username)
+		builder.WriteString(" ")
+	}
+
+	builder.WriteString(err.msg)
+
+	if err.wrapped != nil {
+		builder.WriteString(": ")
+		builder.WriteString(err.wrapped.Error())
+	}
+
+	return builder.String()
+}
+
+// Unwrap support Golang's unwrap logic.
+func (err *authorizationError) Unwrap() error {
+	return err.wrapped
 }

--- a/pkg/oauth/external/github/github.go
+++ b/pkg/oauth/external/github/github.go
@@ -169,36 +169,13 @@ func (p provider) AddCustomParameters(req *osincli.AuthorizeRequest) {
 }
 
 // GetUserIdentity implements external/interfaces/Provider.GetUserIdentity
-func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, bool, error) {
+func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, error) {
 	userdata := githubUser{}
 	if _, err := p.getJSON(p.githubUserApiURL, data.AccessToken, &userdata); err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	if userdata.ID == 0 {
-		return nil, false, errors.New("Could not retrieve GitHub id")
-	}
-
-	if len(p.allowedOrganizations) > 0 {
-		userOrgs, err := p.getUserOrgs(data.AccessToken)
-		if err != nil {
-			return nil, false, err
-		}
-
-		if !userOrgs.HasAny(p.allowedOrganizations.List()...) {
-			return nil, false, fmt.Errorf("User %s is not a member of any allowed organizations %v (user is a member of %v)", userdata.Login, p.allowedOrganizations.List(), userOrgs.List())
-		}
-		klog.V(4).Infof("User %s is a member of organizations %v)", userdata.Login, userOrgs.List())
-	}
-	if len(p.allowedTeams) > 0 {
-		userTeams, err := p.getUserTeams(data.AccessToken)
-		if err != nil {
-			return nil, false, err
-		}
-
-		if !userTeams.HasAny(p.allowedTeams.List()...) {
-			return nil, false, fmt.Errorf("User %s is not a member of any allowed teams %v (user is a member of %v)", userdata.Login, p.allowedTeams.List(), userTeams.List())
-		}
-		klog.V(4).Infof("User %s is a member of teams %v)", userdata.Login, userTeams.List())
+		return nil, errors.New("Could not retrieve GitHub id")
 	}
 
 	// The returned email is empty if the user has not specified a public email address in their profile
@@ -223,7 +200,31 @@ func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdenti
 	}
 	klog.V(4).Infof("Got identity=%#v", identity)
 
-	return identity, true, nil
+	// Apply authorization rules
+	if len(p.allowedOrganizations) > 0 {
+		userOrgs, err := p.getUserOrgs(data.AccessToken)
+		if err != nil {
+			return identity, err
+		}
+
+		if !userOrgs.HasAny(p.allowedOrganizations.List()...) {
+			return identity, newAuthorizationErrorf("User %s is not a member of any allowed organizations %v (user is a member of %v)", userdata.Login, p.allowedOrganizations.List(), userOrgs.List())
+		}
+		klog.V(4).Infof("User %s is a member of organizations %v)", userdata.Login, userOrgs.List())
+	}
+	if len(p.allowedTeams) > 0 {
+		userTeams, err := p.getUserTeams(data.AccessToken)
+		if err != nil {
+			return identity, err
+		}
+
+		if !userTeams.HasAny(p.allowedTeams.List()...) {
+			return identity, newAuthorizationErrorf("User %s is not a member of any allowed teams %v (user is a member of %v)", userdata.Login, p.allowedTeams.List(), userTeams.List())
+		}
+		klog.V(4).Infof("User %s is a member of teams %v)", userdata.Login, userTeams.List())
+	}
+
+	return identity, nil
 }
 
 // getUserOrgs retrieves the organization membership for the user with the given access token.

--- a/pkg/oauth/external/github/github_test.go
+++ b/pkg/oauth/external/github/github_test.go
@@ -1,0 +1,201 @@
+package github
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/RangelReale/osincli"
+	"github.com/openshift/oauth-server/pkg/api"
+	"github.com/openshift/oauth-server/pkg/oauth/external"
+)
+
+func TestGetUserIdentity(t *testing.T) {
+	newGithubIdentityProvider := func(userID uint64, orgs []string) http.RoundTripper {
+		return roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			body := new(bytes.Buffer)
+
+			switch req.URL.Path {
+			case "/user":
+				if err := json.NewEncoder(body).Encode(struct {
+					ID                 uint64
+					Login, Email, Name string
+				}{
+					ID:    userID,
+					Login: "loginname",
+					Email: "user@example.com",
+					Name:  "drago_tommasone",
+				}); err != nil {
+					panic(err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     http.StatusText(http.StatusOK),
+					Body:       io.NopCloser(body),
+				}, nil
+
+			case "/user/orgs":
+				type ghOrg struct {
+					ID    uint64
+					Login string
+				}
+				ghOrgs := make([]ghOrg, len(orgs))
+				for i := range orgs {
+					ghOrgs[i] = ghOrg{
+						ID:    999,
+						Login: orgs[i],
+					}
+
+				}
+
+				if err := json.NewEncoder(body).Encode(ghOrgs); err != nil {
+					panic(err)
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     http.StatusText(http.StatusOK),
+					Body:       io.NopCloser(body),
+				}, nil
+
+			default:
+				return nil, fmt.Errorf("this fixture does not serve the requested path: %s", req.URL.Path)
+			}
+		})
+	}
+
+	type checkFunc func(api.UserIdentityInfo, error) error
+	checks := func(fns ...checkFunc) []checkFunc { return fns }
+
+	hasUserID := func(want string) checkFunc {
+		return func(userIdentityInfo api.UserIdentityInfo, _ error) error {
+			if have := userIdentityInfo.GetIdentityName(); want != have {
+				return fmt.Errorf("expected username %q, got %q", want, have)
+			}
+			return nil
+		}
+	}
+	isAllowed := func(_ api.UserIdentityInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("unexpected error: %v", err)
+		}
+		return nil
+	}
+	isDenied := func(_ api.UserIdentityInfo, err error) error {
+		if err == nil {
+			return fmt.Errorf("expected authorization error, got nil")
+		}
+		var authError external.AuthorizationError
+		if !errors.As(err, &authError) {
+			return fmt.Errorf("expected authorization error, got %v", err)
+		}
+		return nil
+	}
+	throwsError := func(_ api.UserIdentityInfo, err error) error {
+		if err == nil {
+			return fmt.Errorf("expected error, got nil")
+		}
+		return nil
+	}
+
+	for _, tc := range [...]struct {
+		name                 string
+		userID               uint64
+		userOrganizations    []string
+		allowedOrganizations []string
+
+		checks []checkFunc
+	}{
+		{
+			name:   "ok",
+			userID: 123654,
+			checks: checks(
+				isAllowed,
+				hasUserID("git-tub:123654"),
+			),
+		},
+		{
+			name:                 "ok with organization check",
+			userID:               564738,
+			userOrganizations:    []string{"vip"},
+			allowedOrganizations: []string{"vip"},
+			checks: checks(
+				isAllowed,
+				hasUserID("git-tub:564738"),
+			),
+		},
+		{
+			name:                 "ok with organization check, member of multiple",
+			userID:               564738,
+			userOrganizations:    []string{"openshift", "gophercloud", "vip", "kubernetes"},
+			allowedOrganizations: []string{"vip"},
+			checks: checks(
+				isAllowed,
+				hasUserID("git-tub:564738"),
+			),
+		},
+		{
+			name:                 "ok with organization check, multiple allowed",
+			userID:               564738,
+			userOrganizations:    []string{"vip"},
+			allowedOrganizations: []string{"vip", "openshift", "kubernetes"},
+			checks: checks(
+				isAllowed,
+				hasUserID("git-tub:564738"),
+			),
+		},
+		{
+			name:                 "denied, not in organization",
+			userID:               98765491,
+			userOrganizations:    []string{"microsoft"},
+			allowedOrganizations: []string{"neovim"},
+			checks: checks(
+				isDenied,
+				hasUserID("git-tub:98765491"),
+			),
+		},
+		{
+			name:                 "denied, not in any organization",
+			userID:               987654,
+			allowedOrganizations: []string{"vip"},
+			checks: checks(
+				isDenied,
+				hasUserID("git-tub:987654"),
+			),
+		},
+		{
+			name: "denied, no userID",
+			checks: checks(
+				throwsError,
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			userIdentityInfo, err := NewProvider(
+				"git-tub",
+				"my_client_id",
+				"my_client_secret",
+				"",
+				newGithubIdentityProvider(tc.userID, tc.userOrganizations),
+				tc.allowedOrganizations,
+				nil,
+			).GetUserIdentity(&osincli.AccessData{})
+
+			for _, check := range tc.checks {
+				if e := check(userIdentityInfo, err); e != nil {
+					t.Error(e)
+				}
+			}
+		})
+	}
+
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (rt roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rt(req)
+}

--- a/pkg/oauth/external/gitlab/gitlab_oauth.go
+++ b/pkg/oauth/external/gitlab/gitlab_oauth.go
@@ -81,7 +81,7 @@ func (p *provider) NewConfig() (*osincli.ClientConfig, error) {
 func (p *provider) AddCustomParameters(req *osincli.AuthorizeRequest) {}
 
 // GetUserIdentity implements external/interfaces/Provider.GetUserIdentity
-func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, bool, error) {
+func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, error) {
 	req, _ := http.NewRequest("GET", p.userAPIURL, nil)
 	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", data.AccessToken))
 
@@ -91,23 +91,23 @@ func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdenti
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 	defer res.Body.Close()
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	userdata := gitlabUser{}
 	err = json.Unmarshal(body, &userdata)
 	if err != nil {
-		return nil, false, err
+		return nil, err
 	}
 
 	if userdata.ID == 0 {
-		return nil, false, errors.New("Could not retrieve GitLab id")
+		return nil, errors.New("Could not retrieve GitLab id")
 	}
 
 	identity := authapi.NewDefaultUserIdentityInfo(p.providerName, fmt.Sprintf("%d", userdata.ID))
@@ -122,5 +122,5 @@ func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdenti
 	}
 	klog.V(4).Infof("Got identity=%#v", identity)
 
-	return identity, true, nil
+	return identity, nil
 }

--- a/pkg/oauth/external/gitlab/gitlab_oauth.go
+++ b/pkg/oauth/external/gitlab/gitlab_oauth.go
@@ -82,7 +82,10 @@ func (p *provider) AddCustomParameters(req *osincli.AuthorizeRequest) {}
 
 // GetUserIdentity implements external/interfaces/Provider.GetUserIdentity
 func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdentityInfo, error) {
-	req, _ := http.NewRequest("GET", p.userAPIURL, nil)
+	req, err := http.NewRequest("GET", p.userAPIURL, nil)
+	if err != nil {
+		return nil, err
+	}
 	req.Header.Set("Authorization", fmt.Sprintf("bearer %s", data.AccessToken))
 
 	client := http.DefaultClient
@@ -101,8 +104,7 @@ func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdenti
 	}
 
 	userdata := gitlabUser{}
-	err = json.Unmarshal(body, &userdata)
-	if err != nil {
+	if err = json.Unmarshal(body, &userdata); err != nil {
 		return nil, err
 	}
 

--- a/pkg/oauth/external/handler_test.go
+++ b/pkg/oauth/external/handler_test.go
@@ -9,13 +9,16 @@ import (
 	"time"
 
 	"github.com/RangelReale/osincli"
-	"github.com/openshift/oauth-server/pkg/api"
-	"github.com/openshift/oauth-server/pkg/oauth/handlers"
-	"github.com/openshift/oauth-server/pkg/server/csrf"
+
 	auditapi "k8s.io/apiserver/pkg/apis/audit"
-	"k8s.io/apiserver/pkg/audit"
+	kaudit "k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+
+	"github.com/openshift/oauth-server/pkg/api"
+	"github.com/openshift/oauth-server/pkg/audit"
+	"github.com/openshift/oauth-server/pkg/oauth/handlers"
+	"github.com/openshift/oauth-server/pkg/server/csrf"
 )
 
 func TestHandler(t *testing.T) {
@@ -24,114 +27,126 @@ func TestHandler(t *testing.T) {
 	_ = handlers.NewUnionAuthenticationHandler(nil, redirectors, nil, nil)
 }
 
-func TestHandlerLogin(t *testing.T) {
-	t.Run("audit", func(t *testing.T) {
-		type checkFunc func(*auditapi.Event, authenticationHandler) error
-		checks := func(fns ...checkFunc) []checkFunc { return fns }
+func TestHandlerLoginAuditing(t *testing.T) {
+	type checkFunc func(*auditapi.Event, authenticationHandler) error
+	checks := func(fns ...checkFunc) []checkFunc { return fns }
 
-		eventHasUsername := func(want string) checkFunc {
-			return func(ev *auditapi.Event, _ authenticationHandler) error {
-				if want, have := "testprovider:"+want, ev.Annotations["authentication.openshift.io/username"]; want != have {
-					return fmt.Errorf("expected username %q, found %q", want, have)
-				}
-				return nil
-			}
-		}
-		eventHasDecision := func(want string) checkFunc {
-			return func(ev *auditapi.Event, _ authenticationHandler) error {
-				if have := ev.Annotations["authentication.openshift.io/decision"]; want != have {
-					return fmt.Errorf("expected decision %q, found %q", want, have)
-				}
-				return nil
-			}
-		}
-		isAuthorized := func(_ *auditapi.Event, h authenticationHandler) error {
-			if !h.success {
-				return fmt.Errorf("expected call to success handler did not happen")
-			}
-			if h.failure {
-				return fmt.Errorf("unexpected call to error handler")
+	eventHasUsername := func(want string) checkFunc {
+		return func(ev *auditapi.Event, _ authenticationHandler) error {
+			have := ev.Annotations[audit.UsernameAnnotation]
+			if want != have {
+				return fmt.Errorf("expected username %q, found %q", want, have)
 			}
 			return nil
 		}
-		isNotAuthorized := func(_ *auditapi.Event, h authenticationHandler) error {
-			if !h.failure {
-				return fmt.Errorf("expected call to error handler did not happen")
-			}
-			if h.success {
-				return fmt.Errorf("unexpected call to success handler")
+	}
+
+	eventHasDecision := func(want string) checkFunc {
+		return func(ev *auditapi.Event, _ authenticationHandler) error {
+			if have := ev.Annotations[audit.DecisionAnnotation]; want != have {
+				return fmt.Errorf("expected decision %q, found %q", want, have)
 			}
 			return nil
 		}
+	}
 
-		for _, tc := range [...]struct {
-			name     string
-			username string
-			err      error
-			checks   []checkFunc
-		}{
-			{
-				name:     "authorized",
-				username: "boucle_d_or",
-				err:      nil,
-				checks: checks(
-					eventHasUsername("boucle_d_or"),
-					eventHasDecision("allow"),
-					isAuthorized,
-				),
-			},
-			{
-				name:     "error",
-				username: "boucle_d_or",
-				err:      fmt.Errorf("identity provider error"),
-				checks: checks(
-					eventHasUsername("boucle_d_or"),
-					eventHasDecision("error"),
-					isNotAuthorized,
-				),
-			},
-			{
-				name:     "unauthorized",
-				username: "boucle_d_or",
-				err:      authError("authorization error"),
-				checks: checks(
-					eventHasUsername("boucle_d_or"),
-					eventHasDecision("deny"),
-					isNotAuthorized,
-				),
-			},
-		} {
-			t.Run(tc.name, func(t *testing.T) {
-				authHandler := new(authenticationHandler)
-				h := Handler{
-					provider: provider{
-						name:     "testprovider",
-						username: tc.username,
-						err:      tc.err,
-					},
-					mapper:       new(userIdentityMapper),
-					success:      authHandler,
-					errorHandler: authHandler,
-				}
-
-				req := httptest.NewRequest(http.MethodPost, "https://auth.example.com/callback", nil)
-				req = req.WithContext(audit.WithAuditAnnotations(req.Context()))
-
-				h.login(httptest.NewRecorder(), req, nil, "state")
-
-				ev, err := audit.NewEventFromRequest(req, time.Time{}, "Request", attributes{})
-				if err != nil {
-					t.Fatalf("unexpected error in retrieving the audit events: %v", err)
-				}
-
-				for _, check := range tc.checks {
-					if err := check(ev, *authHandler); err != nil {
-						t.Error(err)
-					}
-				}
-			})
+	isAuthorized := func(_ *auditapi.Event, h authenticationHandler) error {
+		if !h.success {
+			return fmt.Errorf("expected call to success handler did not happen")
 		}
-	})
+
+		if h.failure {
+			return fmt.Errorf("unexpected call to error handler")
+		}
+
+		return nil
+	}
+
+	isNotAuthorized := func(_ *auditapi.Event, h authenticationHandler) error {
+		if !h.failure {
+			return fmt.Errorf("expected call to error handler did not happen")
+		}
+
+		if h.success {
+			return fmt.Errorf("unexpected call to success handler")
+		}
+
+		return nil
+	}
+
+	for _, tc := range [...]struct {
+		name     string
+		username string
+		err      error
+		checks   []checkFunc
+	}{
+		{
+			name:     "authorized",
+			username: "franta",
+			err:      nil,
+			checks: checks(
+				eventHasUsername("franta"),
+				eventHasDecision("allow"),
+				isAuthorized,
+			),
+		},
+		{
+			name:     "error",
+			username: "franta",
+			err:      fmt.Errorf("identity provider error"),
+			checks: checks(
+				eventHasDecision("error"),
+				isNotAuthorized,
+			),
+		},
+		{
+			name:     "unauthorized",
+			username: "franta",
+			err: &authError{
+				msg:      "authorization error",
+				username: "franta",
+			},
+			checks: checks(
+				eventHasUsername("franta"),
+				eventHasDecision("deny"),
+				isNotAuthorized,
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			authHandler := new(authenticationHandler)
+			h := Handler{
+				provider: provider{
+					name:     "testprovider",
+					username: tc.username,
+					err:      tc.err,
+				},
+				mapper:       new(userIdentityMapper),
+				success:      authHandler,
+				errorHandler: authHandler,
+			}
+
+			req := httptest.NewRequest(http.MethodPost, "https://auth.example.com/callback", nil)
+			req = req.WithContext(kaudit.WithAuditAnnotations(req.Context()))
+
+			h.authenticate(httptest.NewRecorder(), req, nil, "state")
+
+			ev, err := kaudit.NewEventFromRequest(
+				req, time.Now(),
+				auditapi.LevelRequest,
+				&authorizer.AttributesRecord{},
+			)
+			if err != nil {
+				t.Fatalf("unexpected error in retrieving the audit events: %v", err)
+			}
+
+			for _, check := range tc.checks {
+				if err := check(ev, *authHandler); err != nil {
+					t.Error(err)
+				}
+			}
+		})
+	}
 }
 
 func TestRedirectingStateValidCSRF(t *testing.T) {
@@ -266,56 +281,48 @@ func TestRedirectingStateError(t *testing.T) {
 	}
 }
 
-type attributes struct {
-	authorizer.Attributes
-}
-
-func (attributes) GetUser() user.Info      { return nil }
-func (attributes) GetVerb() string         { return "" }
-func (attributes) IsResourceRequest() bool { return false }
-
 type provider struct {
+	Provider
+
 	name     string
 	username string
 	err      error
 }
 
-func (provider) NewConfig() (*osincli.ClientConfig, error)     { return nil, nil }
-func (provider) GetTransport() (http.RoundTripper, error)      { return nil, nil }
-func (provider) AddCustomParameters(*osincli.AuthorizeRequest) {}
 func (p provider) GetUserIdentity(*osincli.AccessData) (api.UserIdentityInfo, error) {
-	return userIdentityInfo{providerName: p.name, username: p.username}, p.err
+	return userIdentityInfo{
+		providerName: p.name,
+		username:     p.username,
+	}, p.err
 }
 
 type userIdentityInfo struct {
 	providerName string
 	username     string
+
+	api.UserIdentityInfo
 }
 
-func (u userIdentityInfo) GetIdentityName() string {
-	return u.GetProviderName() + ":" + u.GetProviderUserName()
+func (u userIdentityInfo) GetProviderPreferredUserName() string {
+	return u.username
 }
-func (u userIdentityInfo) GetProviderName() string            { return u.providerName }
-func (u userIdentityInfo) GetProviderUserName() string        { return u.username }
-func (userIdentityInfo) GetProviderGroups() []string          { return nil }
-func (userIdentityInfo) GetExtra() map[string]string          { return make(map[string]string) }
-func (userIdentityInfo) GetProviderPreferredUserName() string { return "" }
 
 type userInfo struct {
+	user.Info
+
 	username string
 }
 
-func (u userInfo) GetName() string             { return u.username }
-func (userInfo) GetUID() string                { return "123" }
-func (userInfo) GetGroups() []string           { return []string{"wheel"} }
-func (userInfo) GetExtra() map[string][]string { return make(map[string][]string) }
+func (u userInfo) GetName() string {
+	return u.username
+}
 
 type userIdentityMapper struct{}
 
 // UserFor takes an identity, ignores the passed identity.Provider, forces the provider value to some other value and then creates the mapping.
 // It returns the corresponding user.Info
 func (userIdentityMapper) UserFor(identityInfo api.UserIdentityInfo) (user.Info, error) {
-	return userInfo{identityInfo.GetProviderUserName()}, nil
+	return userInfo{username: identityInfo.GetProviderPreferredUserName()}, nil
 }
 
 type authenticationHandler struct {
@@ -332,7 +339,10 @@ func (h *authenticationHandler) AuthenticationError(error, http.ResponseWriter, 
 	return true, nil
 }
 
-type authError string
+type authError struct {
+	msg      string
+	username string
+}
 
-func (err authError) AuthorizationDenialReason() string { return string(err) }
-func (err authError) Error() string                     { return string(err) }
+func (err *authError) Username() string { return err.username }
+func (err *authError) Error() string    { return err.msg }

--- a/pkg/oauth/external/handler_test.go
+++ b/pkg/oauth/external/handler_test.go
@@ -2,20 +2,136 @@ package external
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/RangelReale/osincli"
+	"github.com/openshift/oauth-server/pkg/api"
 	"github.com/openshift/oauth-server/pkg/oauth/handlers"
 	"github.com/openshift/oauth-server/pkg/server/csrf"
+	auditapi "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
 func TestHandler(t *testing.T) {
 	redirectors := new(handlers.AuthenticationRedirectors)
 	redirectors.Add("handler", &Handler{})
 	_ = handlers.NewUnionAuthenticationHandler(nil, redirectors, nil, nil)
+}
+
+func TestHandlerLogin(t *testing.T) {
+	t.Run("audit", func(t *testing.T) {
+		type checkFunc func(*auditapi.Event, authenticationHandler) error
+		checks := func(fns ...checkFunc) []checkFunc { return fns }
+
+		eventHasUsername := func(want string) checkFunc {
+			return func(ev *auditapi.Event, _ authenticationHandler) error {
+				if want, have := "testprovider:"+want, ev.Annotations["authentication.openshift.io/username"]; want != have {
+					return fmt.Errorf("expected username %q, found %q", want, have)
+				}
+				return nil
+			}
+		}
+		eventHasDecision := func(want string) checkFunc {
+			return func(ev *auditapi.Event, _ authenticationHandler) error {
+				if have := ev.Annotations["authentication.openshift.io/decision"]; want != have {
+					return fmt.Errorf("expected decision %q, found %q", want, have)
+				}
+				return nil
+			}
+		}
+		isAuthorized := func(_ *auditapi.Event, h authenticationHandler) error {
+			if !h.success {
+				return fmt.Errorf("expected call to success handler did not happen")
+			}
+			if h.failure {
+				return fmt.Errorf("unexpected call to error handler")
+			}
+			return nil
+		}
+		isNotAuthorized := func(_ *auditapi.Event, h authenticationHandler) error {
+			if !h.failure {
+				return fmt.Errorf("expected call to error handler did not happen")
+			}
+			if h.success {
+				return fmt.Errorf("unexpected call to success handler")
+			}
+			return nil
+		}
+
+		for _, tc := range [...]struct {
+			name     string
+			username string
+			err      error
+			checks   []checkFunc
+		}{
+			{
+				name:     "authorized",
+				username: "boucle_d_or",
+				err:      nil,
+				checks: checks(
+					eventHasUsername("boucle_d_or"),
+					eventHasDecision("allow"),
+					isAuthorized,
+				),
+			},
+			{
+				name:     "error",
+				username: "boucle_d_or",
+				err:      fmt.Errorf("identity provider error"),
+				checks: checks(
+					eventHasUsername("boucle_d_or"),
+					eventHasDecision("error"),
+					isNotAuthorized,
+				),
+			},
+			{
+				name:     "unauthorized",
+				username: "boucle_d_or",
+				err:      authError("authorization error"),
+				checks: checks(
+					eventHasUsername("boucle_d_or"),
+					eventHasDecision("deny"),
+					isNotAuthorized,
+				),
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				authHandler := new(authenticationHandler)
+				h := Handler{
+					provider: provider{
+						name:     "testprovider",
+						username: tc.username,
+						err:      tc.err,
+					},
+					mapper:       new(userIdentityMapper),
+					success:      authHandler,
+					errorHandler: authHandler,
+				}
+
+				req := httptest.NewRequest(http.MethodPost, "https://auth.example.com/callback", nil)
+				req = req.WithContext(audit.WithAuditAnnotations(req.Context()))
+
+				h.login(httptest.NewRecorder(), req, nil, "state")
+
+				ev, err := audit.NewEventFromRequest(req, time.Time{}, "Request", attributes{})
+				if err != nil {
+					t.Fatalf("unexpected error in retrieving the audit events: %v", err)
+				}
+
+				for _, check := range tc.checks {
+					if err := check(ev, *authHandler); err != nil {
+						t.Error(err)
+					}
+				}
+			})
+		}
+	})
 }
 
 func TestRedirectingStateValidCSRF(t *testing.T) {
@@ -149,3 +265,74 @@ func TestRedirectingStateError(t *testing.T) {
 		t.Errorf("Expected original error back, got %#v", err)
 	}
 }
+
+type attributes struct {
+	authorizer.Attributes
+}
+
+func (attributes) GetUser() user.Info      { return nil }
+func (attributes) GetVerb() string         { return "" }
+func (attributes) IsResourceRequest() bool { return false }
+
+type provider struct {
+	name     string
+	username string
+	err      error
+}
+
+func (provider) NewConfig() (*osincli.ClientConfig, error)     { return nil, nil }
+func (provider) GetTransport() (http.RoundTripper, error)      { return nil, nil }
+func (provider) AddCustomParameters(*osincli.AuthorizeRequest) {}
+func (p provider) GetUserIdentity(*osincli.AccessData) (api.UserIdentityInfo, error) {
+	return userIdentityInfo{providerName: p.name, username: p.username}, p.err
+}
+
+type userIdentityInfo struct {
+	providerName string
+	username     string
+}
+
+func (u userIdentityInfo) GetIdentityName() string {
+	return u.GetProviderName() + ":" + u.GetProviderUserName()
+}
+func (u userIdentityInfo) GetProviderName() string            { return u.providerName }
+func (u userIdentityInfo) GetProviderUserName() string        { return u.username }
+func (userIdentityInfo) GetProviderGroups() []string          { return nil }
+func (userIdentityInfo) GetExtra() map[string]string          { return make(map[string]string) }
+func (userIdentityInfo) GetProviderPreferredUserName() string { return "" }
+
+type userInfo struct {
+	username string
+}
+
+func (u userInfo) GetName() string             { return u.username }
+func (userInfo) GetUID() string                { return "123" }
+func (userInfo) GetGroups() []string           { return []string{"wheel"} }
+func (userInfo) GetExtra() map[string][]string { return make(map[string][]string) }
+
+type userIdentityMapper struct{}
+
+// UserFor takes an identity, ignores the passed identity.Provider, forces the provider value to some other value and then creates the mapping.
+// It returns the corresponding user.Info
+func (userIdentityMapper) UserFor(identityInfo api.UserIdentityInfo) (user.Info, error) {
+	return userInfo{identityInfo.GetProviderUserName()}, nil
+}
+
+type authenticationHandler struct {
+	success bool
+	failure bool
+}
+
+func (h *authenticationHandler) AuthenticationSucceeded(user.Info, string, http.ResponseWriter, *http.Request) (bool, error) {
+	h.success = true
+	return true, nil
+}
+func (h *authenticationHandler) AuthenticationError(error, http.ResponseWriter, *http.Request) (bool, error) {
+	h.failure = true
+	return true, nil
+}
+
+type authError string
+
+func (err authError) AuthorizationDenialReason() string { return string(err) }
+func (err authError) Error() string                     { return string(err) }

--- a/pkg/oauth/external/interfaces.go
+++ b/pkg/oauth/external/interfaces.go
@@ -17,8 +17,12 @@ type Provider interface {
 	GetTransport() (http.RoundTripper, error)
 	// AddCustomParameters allows an external oauth provider to provide parameters that are extension to the spec.  Some providers require this.
 	AddCustomParameters(*osincli.AuthorizeRequest)
-	// GetUserIdentity takes the external oauth token information this and returns the user identity, isAuthenticated, and error
-	GetUserIdentity(*osincli.AccessData) (authapi.UserIdentityInfo, bool, error)
+	// GetUserIdentity takes the external oauth token information this and
+	// returns the user identity and a non-nil error in case of failed
+	// authentication or authorization. The user identity must be returned
+	// when available, including when authorization fails. Authorization
+	// errors must implement AuthorizationError.
+	GetUserIdentity(*osincli.AccessData) (authapi.UserIdentityInfo, error)
 }
 
 // State handles generating and verifying the state parameter round-tripped to an external OAuth flow.
@@ -26,4 +30,9 @@ type Provider interface {
 type State interface {
 	Generate(w http.ResponseWriter, req *http.Request) (string, error)
 	Check(state string, req *http.Request) (bool, error)
+}
+
+type AuthorizationError interface {
+	error
+	AuthorizationDenialReason() string
 }

--- a/pkg/oauth/external/interfaces.go
+++ b/pkg/oauth/external/interfaces.go
@@ -32,7 +32,9 @@ type State interface {
 	Check(state string, req *http.Request) (bool, error)
 }
 
+// AuthorizationError is an error type that stores the username that ran into an
+// error.
 type AuthorizationError interface {
 	error
-	AuthorizationDenialReason() string
+	Username() string
 }

--- a/pkg/oauthserver/auth.go
+++ b/pkg/oauthserver/auth.go
@@ -399,7 +399,14 @@ func (c *OAuthServerConfig) getAuthenticationHandler(mux oauthserver.Mux, errorH
 			oauthErrorHandler := handlers.AuthenticationErrorHandlers{errorHandler, state}
 
 			callbackPath := path.Join(openShiftOAuthCallbackPrefix, identityProvider.Name)
-			oauthRedirector, oauthHandler, err := external.NewExternalOAuthRedirector(oauthProvider, state, c.ExtraOAuthConfig.Options.MasterPublicURL+callbackPath, oauthSuccessHandler, oauthErrorHandler, identityMapper)
+			oauthRedirector, oauthHandler, err := external.NewExternalOAuthRedirector(
+				oauthProvider,
+				state,
+				c.ExtraOAuthConfig.Options.MasterPublicURL+callbackPath,
+				oauthSuccessHandler,
+				oauthErrorHandler,
+				identityMapper,
+			)
 			if err != nil {
 				return nil, fmt.Errorf("unexpected error: %v", err)
 			}
@@ -663,7 +670,10 @@ func (c *OAuthServerConfig) getAuthenticationRequestHandler() (authenticator.Req
 			if err != nil {
 				return nil, err
 			}
-			oauthPasswordAuthenticator, err := external.NewOAuthPasswordAuthenticator(oauthProvider, identityMapper)
+			oauthPasswordAuthenticator, err := external.NewOAuthPasswordAuthenticator(
+				oauthProvider,
+				identityMapper,
+			)
 			if err != nil {
 				return nil, fmt.Errorf("unexpected error: %v", err)
 			}


### PR DESCRIPTION
## What

Add audit logging to external providers like Github, GitLab and OIDC in general.

## Why

Our users would like to audit authentication events.