### PR TITLE
OCPBUGS-33695: p/o/handlers - fix nil-pointer, if ResStatus is nil

### DIFF
--- a/pkg/oauth/handlers/default_auth_handler.go
+++ b/pkg/oauth/handlers/default_auth_handler.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/audit"
 
@@ -116,6 +117,10 @@ func (authHandler *unionAuthenticationHandler) AuthenticationNeeded(apiClient au
 				w.WriteHeader(http.StatusUnauthorized)
 				ev := audit.AuditEventFrom(req.Context())
 				if ev != nil {
+					if ev.ResponseStatus == nil {
+						ev.ResponseStatus = &metav1.Status{}
+					}
+
 					// this code mimics the bits from k8s.io/apiserver/pkg/endpoints/filters/authn_audit.go
 					// but since we don't accept failedHander here we need to manually alter the audit
 					// event with information about failed authentication


### PR DESCRIPTION
## What

Set empty ResponseStatus if nil.

## Why

- If `ResponseStatus` is nil, we have a nil pointer.
- Setting a `ResponseStatus` enables us to set the value from `getAuthMethods(req)`.