### PR TITLE
OCPBUGS-42772: sanitize login path

### DIFF
--- a/pkg/oauthserver/auth.go
+++ b/pkg/oauthserver/auth.go
@@ -353,9 +353,9 @@ func (c *OAuthServerConfig) getAuthenticationHandler(mux oauthserver.Mux, errorH
 					// If there is more than one Identity Provider acting as a login
 					// provider, we need to give each of them their own login path,
 					// to avoid ambiguity.
-					loginPath = path.Join(openShiftLoginPrefix, identityProvider.Name)
-					// url-encode the provider name for redirecting
-					redirectLoginPath = path.Join(openShiftLoginPrefix, (&url.URL{Path: identityProvider.Name}).String())
+					sanitizedPath := path.Join(openShiftLoginPrefix, url.PathEscape(identityProvider.Name))
+					loginPath = sanitizedPath
+					redirectLoginPath = sanitizedPath
 				}
 
 				// Since we're redirecting to a local login page, we don't need to force absolute URL resolution


### PR DESCRIPTION
## What

Sanitize login path.

## Why

We accepted paths that contained illegal character for an URL. Go silently url-encoded them. Now with the new ServeMux in Go 1.22, this is not longer an option as whitespaces are used for a higher logic.