### PR TITLE
OCPBUGS-42772: Fix login path for go1.22 mux pattern matching

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.21-openshift-4.16
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/oauth-server
 
-go 1.21
+go 1.22
 
 require (
 	github.com/davecgh/go-spew v1.1.1

--- a/images/Dockerfile.rhel
+++ b/images/Dockerfile.rhel
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 WORKDIR /go/src/github.com/openshift/oauth-server
 COPY . .
 ENV GO_PACKAGE github.com/openshift/oauth-server
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.17:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/oauth-server/oauth-server /usr/bin/
 ENTRYPOINT ["/usr/bin/oauth-server"]
 LABEL io.k8s.display-name="OpenShift OAuth Server" \

--- a/pkg/oauthserver/auth.go
+++ b/pkg/oauthserver/auth.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/openshift/osin"
 	"github.com/openshift/osincli"
@@ -353,7 +354,7 @@ func (c *OAuthServerConfig) getAuthenticationHandler(mux oauthserver.Mux, errorH
 					// If there is more than one Identity Provider acting as a login
 					// provider, we need to give each of them their own login path,
 					// to avoid ambiguity.
-					loginPath = path.Join(openShiftLoginPrefix, identityProvider.Name)
+					loginPath = path.Join(openShiftLoginPrefix, strings.ReplaceAll(identityProvider.Name, " ", "%20"))
 					// url-encode the provider name for redirecting
 					redirectLoginPath = path.Join(openShiftLoginPrefix, (&url.URL{Path: identityProvider.Name}).String())
 				}

--- a/pkg/oauthserver/auth_test.go
+++ b/pkg/oauthserver/auth_test.go
@@ -1,13 +1,26 @@
 package oauthserver_test
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	osinv1 "github.com/openshift/api/osin/v1"
+	fakeuserclient "github.com/openshift/client-go/user/clientset/versioned/fake"
+	userinformer "github.com/openshift/client-go/user/informers/externalversions"
 	"github.com/openshift/oauth-server/pkg/audit"
+	"github.com/openshift/oauth-server/pkg/oauthserver"
+	"github.com/openshift/oauth-server/pkg/server/session"
+	"github.com/openshift/oauth-server/pkg/userregistry/identitymapper"
 
+	configv1 "github.com/openshift/api/config/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
 	kaudit "k8s.io/apiserver/pkg/audit"
+	fakekube "k8s.io/client-go/kubernetes/fake"
 )
 
 // TestWithOAuth is currently only testing auditing and therefore heavily mocked.
@@ -85,5 +98,149 @@ func TestWithOAuth(t *testing.T) {
 
 			verifyAnnotations(t, tc.given, tc.expected)
 		})
+	}
+}
+
+func TestWithOAuth_loginProviders(t *testing.T) {
+	kubeClient := fakekube.NewSimpleClientset()
+	oauthClient := goodClientRegistry(
+		testClientName,
+		[]string{"myredirect"},
+		[]string{"myscope1", "myscope2"},
+	)
+	kubeAdminIDP := kubeAdmin(t, []byte(testPassword), true, nil)
+	informer := userinformer.NewSharedInformerFactory(
+		fakeuserclient.NewSimpleClientset(),
+		time.Second*30,
+	)
+
+	oauthServerConfig := oauthserver.OAuthServerConfig{
+		ExtraOAuthConfig: oauthserver.ExtraOAuthConfig{
+			KubeClient:              kubeClient,
+			OAuthClientClient:       oauthClient,
+			BootstrapUserDataGetter: kubeAdminIDP,
+			GroupInformer:           informer.User().V1().Groups(),
+			SessionAuth:             session.NewAuthenticator(nil, 10*time.Minute),
+		},
+	}
+
+	expectMethodStatus := map[string]int{
+		http.MethodGet:     http.StatusFound,
+		http.MethodPost:    http.StatusFound,
+		http.MethodHead:    http.StatusMethodNotAllowed,
+		http.MethodPut:     http.StatusMethodNotAllowed,
+		http.MethodPatch:   http.StatusMethodNotAllowed,
+		http.MethodDelete:  http.StatusMethodNotAllowed,
+		http.MethodConnect: http.StatusMethodNotAllowed,
+		http.MethodOptions: http.StatusMethodNotAllowed,
+		http.MethodTrace:   http.StatusMethodNotAllowed,
+	}
+
+	for _, tt := range []struct {
+		name                 string
+		providers            []osinv1.IdentityProvider
+		clientPathEscapeFunc func(string) string
+	}{
+		{
+			name: "single login provider",
+			providers: []osinv1.IdentityProvider{
+				newProvider("idp-no-spaces"),
+			},
+		},
+		{
+			name: "single login provider with spaces in name",
+			providers: []osinv1.IdentityProvider{
+				newProvider("idp with spaces"),
+			},
+		},
+		{
+			name: "multiple login providers",
+			providers: []osinv1.IdentityProvider{
+				newProvider("idp-no-spaces"),
+				newProvider("idp-no-spaces-2"),
+			},
+		},
+		{
+			name: "multiple login providers with spaces in name",
+			providers: []osinv1.IdentityProvider{
+				newProvider("idp-no-spaces"),
+				newProvider("idp with spaces"),
+			},
+		},
+		{
+			name: "multiple login providers with spaces in name and escaped in client",
+			providers: []osinv1.IdentityProvider{
+				newProvider("idp-no-spaces"),
+				newProvider("idp with spaces"),
+			},
+			clientPathEscapeFunc: func(path string) string {
+				return strings.ReplaceAll(path, " ", "%20")
+			},
+		},
+		{
+			name: "multiple login providers with %20 in name",
+			providers: []osinv1.IdentityProvider{
+				newProvider("idp-no-spaces"),
+				newProvider("idp%20with%20spaces"),
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			oauthServerConfig.ExtraOAuthConfig.Options = osinv1.OAuthConfig{
+				LoginURL:          "/login",
+				IdentityProviders: tt.providers,
+				GrantConfig: osinv1.GrantConfig{
+					Method: osinv1.GrantHandlerAuto,
+				},
+			}
+
+			h, err := oauthServerConfig.WithOAuth(http.NewServeMux())
+			if err != nil {
+				t.Errorf("got error while not expecting one: %v", err)
+			}
+
+			for _, p := range tt.providers {
+				loginPath := "/login"
+				if len(tt.providers) > 1 {
+					loginPath += "/" + p.Name
+				}
+
+				for method, expectedStatus := range expectMethodStatus {
+					path := loginPath
+					if tt.clientPathEscapeFunc != nil {
+						path = tt.clientPathEscapeFunc(path)
+					}
+
+					t.Logf("sending '%s %s' to provider '%s'", method, path, p.Name)
+					rec := httptest.NewRecorder()
+					req, err := http.NewRequest(method, path, nil)
+					if err != nil {
+						t.Fatalf("error while creating request: %v", err)
+					}
+
+					h.ServeHTTP(rec, req)
+					res := rec.Result()
+
+					if expectedStatus != res.StatusCode {
+						t.Errorf("expected HTTP status [%d %s]; got [%s]", expectedStatus, http.StatusText(expectedStatus), res.Status)
+					}
+				}
+			}
+		})
+	}
+}
+
+func newProvider(name string) osinv1.IdentityProvider {
+	return osinv1.IdentityProvider{
+		Name:          name,
+		UseAsLogin:    true,
+		MappingMethod: string(identitymapper.MappingMethodClaim),
+		Provider: runtime.RawExtension{
+			Object: &osinv1.BasicAuthPasswordIdentityProvider{
+				RemoteConnectionInfo: configv1.RemoteConnectionInfo{
+					URL: fmt.Sprintf("https://%s.com", name),
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
- bump minimum go to 1.22
- fix login path pattern by escaping spaces
- add some unit tests that prove the fix