### PR TITLE
Remove ancient deprecated header

### DIFF
--- a/pkg/server/headers/headers.go
+++ b/pkg/server/headers/headers.go
@@ -16,7 +16,6 @@ var standardHeaders = map[string]string{
 	// Add other basic security hygiene headers
 	"X-Content-Type-Options": "nosniff",
 	"X-DNS-Prefetch-Control": "off",
-	"X-XSS-Protection":       "1; mode=block",
 }
 
 func WithStandardHeaders(handler http.Handler) http.Handler {


### PR DESCRIPTION
Removes `X-XSS-Protection` and thus addresses #195

This header should really not be set anywhere anymore and it should be phased out.