### PR TITLE
RFE-9629: Add copy to clipboard buttons to display token page

### DIFF
--- a/pkg/server/tokenrequest/tokenrequest.go
+++ b/pkg/server/tokenrequest/tokenrequest.go
@@ -237,32 +237,36 @@ var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(
   {{ .Error }}
 {{ else }}
   <script>
-    function codeSnippet(e, textBlocks) {
-      const snippet = textBlocks.join(' ');
+    function codeSnippet(e, textBlocks = []) {
+      const snippetString = textBlocks.join(' ').trim();
 
       const snippetHTML = textBlocks
-        .map((text) => '<span class="nowrap">' + text + '</span>')
+        .map((text) => {
+          const span = document.createElement('span');
+          span.className = 'nowrap';
+          span.innerText = text;
+          return span.outerHTML;
+        })
         .join(' ');
 
       const copyButton = document.createElement('button');
       copyButton.innerText = 'Copy';
 
+      const resetCopyButton = () => {
+        copyButton.innerText = 'Copy';
+        copyButton.disabled = false;
+      };
+
       copyButton.onclick = () => {
         copyButton.disabled = true;
-        navigator.clipboard.writeText(snippet)
+        navigator.clipboard.writeText(snippetString)
           .then(() => {
             copyButton.innerText = 'Copied!';
-            setTimeout(() => {
-              copyButton.innerText = 'Copy';
-              copyButton.disabled = false;
-            }, 3000);
+            setTimeout(resetCopyButton, 3000);
           })
           .catch((error) => {
             copyButton.innerText = 'Error!';
-            setTimeout(() => {
-              copyButton.innerText = 'Copy';
-              copyButton.disabled = false;
-            }, 3000);
+            setTimeout(resetCopyButton, 3000);
             console.error('Failed to copy snippet to clipboard', error);
           });
       };

--- a/pkg/server/tokenrequest/tokenrequest.go
+++ b/pkg/server/tokenrequest/tokenrequest.go
@@ -219,6 +219,8 @@ const cssStyle = `
 	code     { font-weight: 300; font-size: 1.5em; margin-bottom: 1em; display: inline-block;  color: #646464;  }
 	pre      { padding-left: 1em; border-radius: 5px; color: #003d6e; background-color: #EAEDF0; padding: 1.5em 0 1.5em 4.5em; white-space: normal; text-indent: -2em; }
 	pre>button { margin-left: 1.5em; margin-right: 1.5em; float: right; }
+	pre>button:disabled { color: #444; }
+	pre>button:disabled:hover { text-decoration: none; cursor: default; }
 	a        { color: #00f; text-decoration: none; }
 	a:hover  { text-decoration: underline; }
 	button   { background: none; border: none; color: #00f; text-decoration: none; font: inherit; padding: 0; }
@@ -234,31 +236,77 @@ var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(
 {{ if .Error }}
   {{ .Error }}
 {{ else }}
-  <h2>Your API token is</h2>
-  <code>{{.AccessToken}}</code>
-
   <script>
-    var commands = {
-      login: 'oc login --token={{.AccessTokenJSStr}} --server={{.PublicMasterURLJSStr}}',
-      apiCall: 'curl -H "Authorization: Bearer {{.AccessTokenJSStr}}" "{{.PublicMasterURLJSStr}}/apis/user.openshift.io/v1/users/~"',
-    };
+    function codeSnippet(e, textBlocks) {
+      const snippet = textBlocks.join(' ');
+
+      const snippetHTML = textBlocks
+        .map((text) => '<span class="nowrap">' + text + '</span>')
+        .join(' ');
+
+      const copyButton = document.createElement('button');
+      copyButton.innerText = 'Copy';
+
+      copyButton.onclick = () => {
+        copyButton.disabled = true;
+        navigator.clipboard.writeText(snippet)
+          .then(() => {
+            copyButton.innerText = 'Copied!';
+            setTimeout(() => {
+              copyButton.innerText = 'Copy';
+              copyButton.disabled = false;
+            }, 3000);
+          })
+          .catch((error) => {
+            copyButton.innerText = 'Error!';
+            setTimeout(() => {
+              copyButton.innerText = 'Copy';
+              copyButton.disabled = false;
+            }, 3000);
+            console.error('Failed to copy snippet to clipboard', error);
+          });
+      };
+
+      const showButton = document.createElement('button');
+      showButton.innerText = 'Show';
+
+      showButton.onclick = () => {
+        e.innerHTML = snippetHTML;
+        e.appendChild(copyButton);
+      };
+
+      e.innerHTML = '***';
+      e.appendChild(copyButton);
+      e.appendChild(showButton);
+    }
   </script>
 
+  <h2>Your API token is</h2>
+  <pre id="token"></pre>
+
   <h2>Log in with this token</h2>
-  <pre>
-    oc login
-    <span class="nowrap">--token={{.AccessToken}}</span>
-    <span class="nowrap">--server={{.PublicMasterURL}}</span>
-    <button onclick="navigator.clipboard.writeText(commands.login)">Copy</button>
-  </pre>
+  <pre id="login"></pre>
 
   <h3>Use this token directly against the API</h3>
-  <pre>
-    curl
-    <span class="nowrap">-H "Authorization: Bearer {{.AccessToken}}"</span>
-    <span class="nowrap">"{{.PublicMasterURL}}/apis/user.openshift.io/v1/users/~"</span>
-    <button onclick="navigator.clipboard.writeText(commands.apiCall)">Copy</button>
-  </pre>
+  <pre id="apiCall"></pre>
+
+  <script>
+    codeSnippet(document.getElementById('token'), [
+      '{{.AccessTokenJSStr}}',
+    ]);
+
+    codeSnippet(document.getElementById('login'), [
+      'oc login',
+      '--token={{.AccessTokenJSStr}}',
+      '--server={{.PublicMasterURLJSStr}}',
+    ]);
+
+    codeSnippet(document.getElementById('apiCall'), [
+      'curl',
+      '-H "Authorization: Bearer {{.AccessTokenJSStr}}"',
+      '"{{.PublicMasterURLJSStr}}/apis/user.openshift.io/v1/users/~"',
+    ]);
+  </script>
 {{ end }}
 
 <br><br>

--- a/pkg/server/tokenrequest/tokenrequest.go
+++ b/pkg/server/tokenrequest/tokenrequest.go
@@ -144,6 +144,8 @@ func (t *tokenRequest) displayTokenPost(osinOAuthClient *osincli.Client, w http.
 	}
 
 	data.AccessToken = accessData.AccessToken
+	data.AccessTokenJSStr = template.JSStr(data.AccessToken)
+	data.PublicMasterURLJSStr = template.JSStr(data.PublicMasterURL)
 	renderToken(w, data)
 }
 
@@ -178,9 +180,11 @@ type sharedData struct {
 type tokenData struct {
 	sharedData
 
-	AccessToken     string
-	PublicMasterURL string
-	LogoutURL       string
+	AccessToken          string
+	AccessTokenJSStr     template.JSStr
+	PublicMasterURL      string
+	PublicMasterURLJSStr template.JSStr
+	LogoutURL            string
 }
 
 func getBaseURL(req *http.Request) (*url.URL, error) {
@@ -214,6 +218,7 @@ const cssStyle = `
 	code,pre { font-family: Menlo, Monaco, Consolas, monospace; }
 	code     { font-weight: 300; font-size: 1.5em; margin-bottom: 1em; display: inline-block;  color: #646464;  }
 	pre      { padding-left: 1em; border-radius: 5px; color: #003d6e; background-color: #EAEDF0; padding: 1.5em 0 1.5em 4.5em; white-space: normal; text-indent: -2em; }
+	pre>button { margin-left: 1.5em; margin-right: 1.5em; float: right; }
 	a        { color: #00f; text-decoration: none; }
 	a:hover  { text-decoration: underline; }
 	button   { background: none; border: none; color: #00f; text-decoration: none; font: inherit; padding: 0; }
@@ -232,11 +237,28 @@ var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(
   <h2>Your API token is</h2>
   <code>{{.AccessToken}}</code>
 
+  <script>
+    var commands = {
+      login: 'oc login --token={{.AccessTokenJSStr}} --server={{.PublicMasterURLJSStr}}',
+      apiCall: 'curl -H "Authorization: Bearer {{.AccessTokenJSStr}}" "{{.PublicMasterURLJSStr}}/apis/user.openshift.io/v1/users/~"',
+    };
+  </script>
+
   <h2>Log in with this token</h2>
-  <pre>oc login <span class="nowrap">--token={{.AccessToken}}</span> <span class="nowrap">--server={{.PublicMasterURL}}</span></pre>
+  <pre>
+    oc login
+    <span class="nowrap">--token={{.AccessToken}}</span>
+    <span class="nowrap">--server={{.PublicMasterURL}}</span>
+    <button onclick="navigator.clipboard.writeText(commands.login)">Copy</button>
+  </pre>
 
   <h3>Use this token directly against the API</h3>
-  <pre>curl <span class="nowrap">-H "Authorization: Bearer {{.AccessToken}}"</span> <span class="nowrap">"{{.PublicMasterURL}}/apis/user.openshift.io/v1/users/~"</span></pre>
+  <pre>
+    curl
+    <span class="nowrap">-H "Authorization: Bearer {{.AccessToken}}"</span>
+    <span class="nowrap">"{{.PublicMasterURL}}/apis/user.openshift.io/v1/users/~"</span>
+    <button onclick="navigator.clipboard.writeText(commands.apiCall)">Copy</button>
+  </pre>
 {{ end }}
 
 <br><br>


### PR DESCRIPTION
This PR modifies the [token display page](https://github.com/openshift/oauth-server/blob/master/pkg/server/tokenrequest/tokenrequest.go) by adding "Show" and "Copy" buttons.

Initially, all snippets have their content hidden using `***` placeholder text.

<img width="974" height="400" src="https://github.com/user-attachments/assets/e14608d4-9e70-4576-afa1-33a2e8263425" />
<br>

Click on "Show" button to reveal the content and make the "Show" button disappear for that snippet.

<img width="974" height="400" src="https://github.com/user-attachments/assets/6c1ab6b6-d524-464b-a0e4-261f6ab9a0b8" />
<br>

Click on "Copy" button to copy the content to clipboard using the standard [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard).

<img width="974" height="400" src="https://github.com/user-attachments/assets/81b0bf08-a4e5-4130-91b5-b2a8c0c840ac" />
<br>

Clicking the "Copy" button changes its text and disables it for 3 seconds, then resets the button to its normal state.
- success - shows "Copied!"
- error - shows "Error!" - note :memo: error is logged to browser console using `console.error`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token and command displays now feature interactive "Copy" and "Show" buttons for improved usability.
  * Copy button provides immediate visual feedback confirming successful copying or indicating errors.
  * Command text rendering now generates on the client-side, enabling better interactivity and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->