### PR TITLE
OCPBUGS-64657: external/openid: Unwrap groups encoded as string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-jose/go-jose/v3 v3.0.3
 	github.com/go-ldap/ldap/v3 v3.4.3
+	github.com/google/go-cmp v0.6.0
 	github.com/gophercloud/gophercloud/v2 v2.4.0
 	github.com/gorilla/sessions v1.2.1
 	github.com/openshift/api v0.0.0-20240410131754-6e4793fb6a4b
@@ -54,7 +55,6 @@ require (
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/cel-go v0.17.7 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect

--- a/pkg/oauth/external/openid/openid_test.go
+++ b/pkg/oauth/external/openid/openid_test.go
@@ -26,7 +26,7 @@ func TestOpenID(t *testing.T) {
 }
 
 func TestDecodeJWT(t *testing.T) {
-	testcases := []struct {
+	testCases := []struct {
 		Name       string
 		JWT        string
 		ExpectData map[string]interface{}
@@ -83,17 +83,16 @@ func TestDecodeJWT(t *testing.T) {
 			ExpectErr: false,
 		},
 	}
-	for i, tc := range testcases {
-		data, err := decodeJWT(tc.JWT)
-		if tc.ExpectErr != (err != nil) {
-			t.Errorf("%d: expected error %v, got %v", i, tc.ExpectErr, err)
-			continue
-
-		}
-		if !reflect.DeepEqual(data, tc.ExpectData) {
-			t.Errorf("%d: expected\n\t%#v\ngot\n\t%#v", i, tc.ExpectData, data)
-			continue
-		}
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			data, err := decodeJWT(tc.JWT)
+			if tc.ExpectErr != (err != nil) {
+				t.Fatalf("expected error %v, got %v", tc.ExpectErr, err)
+			}
+			if !reflect.DeepEqual(data, tc.ExpectData) {
+				t.Fatalf("expected\n\t%#v\ngot\n\t%#v", tc.ExpectData, data)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Unwrap groups array claim when encoded as a simple string.
This means decoding `"groups": "[\"A\", \"B\"]"` into `["A", "B"]`
groups claim value.

I also made the array parsing more strict, failing on unexpected type encountered instead of ignore/panic.

Let me know if we need to add more tests somewhere.