### PR TITLE
CNF-23374: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/authenticator/password/basicauthpassword/basicauthpassword.go
+++ b/pkg/authenticator/password/basicauthpassword/basicauthpassword.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -103,7 +103,7 @@ func (a *Authenticator) AuthenticatePassword(ctx context.Context, username, pass
 		return nil, false, nil
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/authenticator/password/keystonepassword/keystonepassword_test.go
+++ b/pkg/authenticator/password/keystonepassword/keystonepassword_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -59,7 +59,7 @@ func TestKeystoneLogin(t *testing.T) {
 			}
 		}
 		var x AuthRequest
-		body, _ := ioutil.ReadAll(r.Body)
+		body, _ := io.ReadAll(r.Body)
 		th.AssertNoErr(t, json.Unmarshal(body, &x))
 		domainName := x.Auth.Identity.Password.User.Domain.Name
 		userName := x.Auth.Identity.Password.User.Name

--- a/pkg/authenticator/password/keystonepassword/keystonepassword_test.go
+++ b/pkg/authenticator/password/keystonepassword/keystonepassword_test.go
@@ -59,7 +59,8 @@ func TestKeystoneLogin(t *testing.T) {
 			}
 		}
 		var x AuthRequest
-		body, _ := io.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
+		th.AssertNoErr(t, err)
 		th.AssertNoErr(t, json.Unmarshal(body, &x))
 		domainName := x.Auth.Identity.Password.User.Domain.Name
 		userName := x.Auth.Identity.Password.User.Name

--- a/pkg/config/stringsource.go
+++ b/pkg/config/stringsource.go
@@ -4,7 +4,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -31,7 +30,7 @@ func ResolveStringValue(s configv1.StringSource) (string, error) {
 	case len(s.Env) > 0:
 		value = os.Getenv(s.Env)
 	case len(s.File) > 0:
-		data, err := ioutil.ReadFile(s.File)
+		data, err := os.ReadFile(s.File)
 		if err != nil {
 			return "", err
 		}
@@ -45,7 +44,7 @@ func ResolveStringValue(s configv1.StringSource) (string, error) {
 		return value, nil
 	}
 
-	keyData, err := ioutil.ReadFile(s.KeyFile)
+	keyData, err := os.ReadFile(s.KeyFile)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/oauth/external/gitlab/gitlab_oauth.go
+++ b/pkg/oauth/external/gitlab/gitlab_oauth.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -95,7 +95,7 @@ func (p *provider) GetUserIdentity(data *osincli.AccessData) (authapi.UserIdenti
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauth/external/openid/openid.go
+++ b/pkg/oauth/external/openid/openid.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -273,7 +273,7 @@ func fetchUserInfo(url, accessToken string, transport http.RoundTripper) (map[st
 
 	// The UserInfo Claims MUST be returned as the members of a JSON object
 	// http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/oauthserver/auth.go
+++ b/pkg/oauthserver/auth.go
@@ -6,9 +6,9 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"strings"
 
@@ -685,7 +685,7 @@ func (c *OAuthServerConfig) getAuthenticationRequestHandler() (authenticator.Req
 
 				// Wrap with an x509 verifier
 				if len(provider.ClientCA) > 0 {
-					caData, err := ioutil.ReadFile(provider.ClientCA)
+					caData, err := os.ReadFile(provider.ClientCA)
 					if err != nil {
 						return nil, fmt.Errorf("Error reading %s: %v", provider.ClientCA, err)
 					}

--- a/pkg/oauthserver/oauth_apiserver_test.go
+++ b/pkg/oauthserver/oauth_apiserver_test.go
@@ -3,7 +3,6 @@ package oauthserver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -35,13 +34,13 @@ func TestGetMissingSessionSecretsFile(t *testing.T) {
 }
 
 func TestGetInvalidSessionSecretsFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "invalid.yaml")
+	tmpfile, err := os.CreateTemp("", "invalid.yaml")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	defer os.Remove(tmpfile.Name())
 
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte("invalid content"), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte("invalid content"), os.FileMode(0600)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -52,7 +51,7 @@ func TestGetInvalidSessionSecretsFile(t *testing.T) {
 }
 
 func TestGetEmptySessionSecretsFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "empty.yaml")
+	tmpfile, err := os.CreateTemp("", "empty.yaml")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -66,7 +65,7 @@ func TestGetEmptySessionSecretsFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0600)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -168,7 +167,7 @@ func TestConfigureTransport_ProxyCAFileNotFound(t *testing.T) {
 }
 
 func TestGetValidSessionSecretsFile(t *testing.T) {
-	tmpfile, err := ioutil.TempFile("", "valid.yaml")
+	tmpfile, err := os.CreateTemp("", "valid.yaml")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -186,7 +185,7 @@ func TestGetValidSessionSecretsFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := ioutil.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0600)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/oauthserver/oauth_apiserver_test.go
+++ b/pkg/oauthserver/oauth_apiserver_test.go
@@ -40,7 +40,7 @@ func TestGetInvalidSessionSecretsFile(t *testing.T) {
 	}
 	defer os.Remove(tmpfile.Name())
 
-	if err := os.WriteFile(tmpfile.Name(), []byte("invalid content"), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte("invalid content"), os.FileMode(0o600)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -65,7 +65,7 @@ func TestGetEmptySessionSecretsFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := os.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0o600)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -185,7 +185,7 @@ func TestGetValidSessionSecretsFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if err := os.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0600)); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(yaml), os.FileMode(0o600)); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/server/login/login_test.go
+++ b/pkg/server/login/login_test.go
@@ -3,7 +3,7 @@ package login
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -246,7 +246,7 @@ func TestLogin(t *testing.T) {
 		}
 
 		if len(testCase.ExpectContains) > 0 {
-			data, _ := ioutil.ReadAll(resp.Body)
+			data, _ := io.ReadAll(resp.Body)
 			body := string(data)
 			for i := range testCase.ExpectContains {
 				if !strings.Contains(body, testCase.ExpectContains[i]) {

--- a/pkg/server/selectprovider/selectprovider_test.go
+++ b/pkg/server/selectprovider/selectprovider_test.go
@@ -1,7 +1,7 @@
 package selectprovider
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -96,7 +96,7 @@ func TestSelectAuthentication(t *testing.T) {
 		}
 
 		if len(testCase.ExpectContains) > 0 {
-			data, _ := ioutil.ReadAll(resp.Body)
+			data, _ := io.ReadAll(resp.Body)
 			body := string(data)
 			for i := range testCase.ExpectContains {
 				if !strings.Contains(body, testCase.ExpectContains[i]) {


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

**Core updates to file and stream reading:**

* Replaced `ioutil.ReadAll` with `io.ReadAll` for reading from streams and HTTP response bodies across authentication, OAuth, and server-related packages. [[1]](diffhunk://#diff-6e53cae06907e227362b3d12d7410d2e5067d513e0634c8e25e51fdb3949f88dL106-R106) [[2]](diffhunk://#diff-fde9ab93c895a89d6ab85f3bef72b90fea8813d455b1ad94a31e79b9f563b012L98-R98) [[3]](diffhunk://#diff-92e6695947533639cf025d8165b5c0bc39334a4899ff1a1e22fba25936caaf15L276-R276) [[4]](diffhunk://#diff-8517ba6e56f5ace415c970d7e5fe811f56ac5004b178d8893c02dfb60d75a1e7L62-R62) [[5]](diffhunk://#diff-080c7f99306c1c2a6a0337b4d972211d7af595c22126a6f822cd51c8a4e03273L470-R470) [[6]](diffhunk://#diff-46623963a14c8005bf78c737b2990471889e7f09179bdde1209603d3d55672adL249-R249) [[7]](diffhunk://#diff-e612bd876e84a57f9c6d11f73a497d6f99f6759b8a41339ef0784dc743cbe4e6L99-R99)
* Replaced `ioutil.ReadFile` with `os.ReadFile` for reading files in configuration and OAuth server logic, such as loading secrets and certificates. [[1]](diffhunk://#diff-520d203d74db4a7e2864c3aacc58dc6f70d6f802fda4245334ab0ecd71244d89L89-R88) [[2]](diffhunk://#diff-9c98b3007090dd0a7165184614b844fca1903f537fa20c41dc49de1a9da0b91bL34-R33) [[3]](diffhunk://#diff-9c98b3007090dd0a7165184614b844fca1903f537fa20c41dc49de1a9da0b91bL48-R47) [[4]](diffhunk://#diff-26eb62ac396048ba3dc28ae5764caf68710f82c7956d15af24dfef8542c7fbc8L688-R688) [[5]](diffhunk://#diff-a951c9a5c34ffe10e191ddc560aeaf36e033cd4ea9e96652aba46b8b51bb1d16L203-R203)

**Test code modernization:**

* Updated tests to use `os.CreateTemp` instead of `ioutil.TempFile` and `os.WriteFile` instead of `ioutil.WriteFile` for creating and writing temporary files. [[1]](diffhunk://#diff-9b71e51315f8a2b954cf0e481c0f0d2cacfd2ffe684cb0f62997782bb8338b87L31-R36) [[2]](diffhunk://#diff-9b71e51315f8a2b954cf0e481c0f0d2cacfd2ffe684cb0f62997782bb8338b87L48-R47) [[3]](diffhunk://#diff-9b71e51315f8a2b954cf0e481c0f0d2cacfd2ffe684cb0f62997782bb8338b87L62-R61) [[4]](diffhunk://#diff-9b71e51315f8a2b954cf0e481c0f0d2cacfd2ffe684cb0f62997782bb8338b87L73-R72) [[5]](diffhunk://#diff-9b71e51315f8a2b954cf0e481c0f0d2cacfd2ffe684cb0f62997782bb8338b87L91-R90)
* Updated imports and usage in test files to use `io.ReadAll` instead of `ioutil.ReadAll` for reading HTTP response bodies. [[1]](diffhunk://#diff-8517ba6e56f5ace415c970d7e5fe811f56ac5004b178d8893c02dfb60d75a1e7L62-R62) [[2]](diffhunk://#diff-080c7f99306c1c2a6a0337b4d972211d7af595c22126a6f822cd51c8a4e03273L470-R470) [[3]](diffhunk://#diff-46623963a14c8005bf78c737b2990471889e7f09179bdde1209603d3d55672adL249-R249) [[4]](diffhunk://#diff-e612bd876e84a57f9c6d11f73a497d6f99f6759b8a41339ef0784dc743cbe4e6L99-R99)

**General import cleanup:**

* Removed unused `ioutil` imports and added necessary `os` or `io` imports in affected files. [[1]](diffhunk://#diff-6e53cae06907e227362b3d12d7410d2e5067d513e0634c8e25e51fdb3949f88dL8-R8) [[2]](diffhunk://#diff-8517ba6e56f5ace415c970d7e5fe811f56ac5004b178d8893c02dfb60d75a1e7L7-R7) [[3]](diffhunk://#diff-520d203d74db4a7e2864c3aacc58dc6f70d6f802fda4245334ab0ecd71244d89L7) [[4]](diffhunk://#diff-9c98b3007090dd0a7165184614b844fca1903f537fa20c41dc49de1a9da0b91bL7) [[5]](diffhunk://#diff-fde9ab93c895a89d6ab85f3bef72b90fea8813d455b1ad94a31e79b9f563b012L7-R7) [[6]](diffhunk://#diff-92e6695947533639cf025d8165b5c0bc39334a4899ff1a1e22fba25936caaf15L8-R8) [[7]](diffhunk://#diff-26eb62ac396048ba3dc28ae5764caf68710f82c7956d15af24dfef8542c7fbc8L9-R11) [[8]](diffhunk://#diff-a951c9a5c34ffe10e191ddc560aeaf36e033cd4ea9e96652aba46b8b51bb1d16L8-R10) [[9]](diffhunk://#diff-9b71e51315f8a2b954cf0e481c0f0d2cacfd2ffe684cb0f62997782bb8338b87L4) [[10]](diffhunk://#diff-080c7f99306c1c2a6a0337b4d972211d7af595c22126a6f822cd51c8a4e03273L5-R5) [[11]](diffhunk://#diff-46623963a14c8005bf78c737b2990471889e7f09179bdde1209603d3d55672adL6-R6) [[12]](diffhunk://#diff-e612bd876e84a57f9c6d11f73a497d6f99f6759b8a41339ef0784dc743cbe4e6L4-R4)

These updates ensure the codebase is up-to-date with the latest Go standards and removes reliance on deprecated APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced deprecated request, response, and file-reading helpers with modern Go standard library equivalents across authentication, OAuth, server, and configuration components.
  * Updated related test utilities for HTTP body handling and temporary-file creation and writing.
  * Preserved existing authentication, certificate handling, error propagation, control flow, test assertions, and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->