### PR TITLE
OCPBUGS-63228: groupmapper: avoid mutating original group users slice when removing user

### DIFF
--- a/pkg/groupmapper/groupmapper.go
+++ b/pkg/groupmapper/groupmapper.go
@@ -3,6 +3,7 @@ package groupmapper
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -142,23 +143,14 @@ func (m *UserGroupsMapper) removeUserFromGroup(idpName, username, group string) 
 	}
 
 	// find the user and remove it from the slice
-	userIdx := -1
-	for i, groupUser := range updatedGroup.Users {
-		if groupUser == username {
-			userIdx = i
-			break
-		}
+	userIdx := slices.Index(updatedGroup.Users, username)
+	if userIdx == -1 {
+		return nil
 	}
 
-	var newUsers []string
-	switch userIdx {
-	case -1:
-		return nil
-	case 0:
-		newUsers = updatedGroup.Users[1:]
-	default:
-		newUsers = append(updatedGroup.Users[0:userIdx], updatedGroup.Users[userIdx+1:]...)
-	}
+	newUsers := make([]string, 0, len(updatedGroup.Users)-1)
+	newUsers = append(newUsers, updatedGroup.Users[:userIdx]...)
+	newUsers = append(newUsers, updatedGroup.Users[userIdx+1:]...)
 
 	updatedGroupCopy := updatedGroup.DeepCopy()
 	updatedGroupCopy.Users = newUsers
@@ -206,7 +198,7 @@ func (m *UserGroupsMapper) addUserToGroup(idpName, username, group string) error
 
 	updatedGroupCopy := updatedGroup.DeepCopy()
 	if !onlyAddAnnotation {
-		updatedGroupCopy.Users = append(updatedGroup.Users, username)
+		updatedGroupCopy.Users = append(updatedGroupCopy.Users, username)
 	}
 	updatedGroupCopy.Annotations[fmt.Sprintf(groupSyncedKeyFmt, idpName)] = "synced"
 

--- a/pkg/groupmapper/groupmapper_test.go
+++ b/pkg/groupmapper/groupmapper_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
@@ -439,6 +440,122 @@ func watchForGroupEvents(
 			return
 		}
 	}
+}
+
+func TestRemoveUserFromGroup_DoesNotMutateCachedObject(t *testing.T) {
+	const testGroupName = "test-group"
+
+	tests := []struct {
+		name          string
+		username      string
+		originalUsers []string
+		expectedUsers []string // users expected in the group after removal
+	}{
+		{
+			name:          "remove middle user (default case)",
+			username:      "user2",
+			originalUsers: []string{"user1", "user2", "user3", "user4"},
+			expectedUsers: []string{"user1", "user3", "user4"},
+		},
+		{
+			name:          "remove first user (case 0)",
+			username:      "user1",
+			originalUsers: []string{"user1", "user2", "user3", "user4"},
+			expectedUsers: []string{"user2", "user3", "user4"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			group := createGroupWithUsers(testGroupName, tt.originalUsers...)
+			fakeUserClient := fakeuserclient.NewSimpleClientset(group)
+
+			// Use a real informer so the lister and GroupCache share the
+			// same underlying indexed store, just like in production.
+			informerFactory := userinformer.NewSharedInformerFactory(fakeUserClient, 0)
+			groupInformer := informerFactory.User().V1().Groups()
+			require.NoError(t, groupInformer.Informer().AddIndexers(cache.Indexers{
+				usercache.ByUserIndexName: usercache.ByUserIndexKeys,
+			}))
+
+			ctx := t.Context()
+			informerFactory.Start(ctx.Done())
+			cache.WaitForCacheSync(ctx.Done(), groupInformer.Informer().HasSynced)
+
+			indexer := groupInformer.Informer().GetIndexer()
+
+			m := &UserGroupsMapper{
+				groupsLister: userlisterv1.NewGroupLister(indexer),
+				groupsClient: fakeUserClient.UserV1().Groups(),
+				groupsCache:  usercache.NewGroupCache(groupInformer),
+			}
+
+			err := m.removeUserFromGroup(testIDPName, tt.username, testGroupName)
+			require.NoError(t, err)
+
+			// Simulate the watch event: the API returns the correctly updated
+			// group, and the informer calls indexer.Update with it. This is
+			// where the re-indexing happens against the (possibly corrupted)
+			// old cached object.
+			updatedGroup := createGroupWithUsers(testGroupName, tt.expectedUsers...)
+			require.NoError(t, indexer.Update(updatedGroup))
+
+			// The removed user should no longer appear in GroupsFor results.
+			// With the bug, the append mutation causes the re-indexer to miss
+			// cleaning up the removed user's index entry, creating a phantom.
+			groups, err := m.groupsCache.GroupsFor(tt.username)
+			require.NoError(t, err)
+			require.False(t, slices.ContainsFunc(groups, func(g *userv1.Group) bool {
+				return g.Name == testGroupName
+			}), "phantom index entry: GroupsFor(%q) still returns %q after user was removed", tt.username, testGroupName)
+		})
+	}
+}
+
+func TestAddUserToGroup_DoesNotMutateCachedObject(t *testing.T) {
+	const testGroupName = "test-group"
+
+	// Create a Users slice with extra capacity so append can write into
+	// the backing array without allocating.
+	users := make(userv1.OptionalNames, 2, 4)
+	users[0] = "user1"
+	users[1] = "user2"
+
+	group := &userv1.Group{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: testGroupName,
+			Annotations: map[string]string{
+				fmt.Sprintf(groupSyncedKeyFmt, testIDPName): "synced",
+				groupGeneratedKey: "true",
+			},
+		},
+		Users: users,
+	}
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	require.NoError(t, indexer.Add(group))
+	fakeUserClient := fakeuserclient.NewSimpleClientset(group)
+
+	m := &UserGroupsMapper{
+		groupsLister: userlisterv1.NewGroupLister(indexer),
+		groupsClient: fakeUserClient.UserV1().Groups(),
+	}
+
+	err := m.addUserToGroup(testIDPName, "user3", testGroupName)
+	require.NoError(t, err)
+
+	obj, exists, err := indexer.GetByKey(testGroupName)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	cachedGroup := obj.(*userv1.Group)
+	require.Equal(t, []string{"user1", "user2"}, []string(cachedGroup.Users),
+		"cached object was mutated: Users changed from [user1 user2] to %v", cachedGroup.Users)
+
+	// Also verify the backing array beyond len was not written to.
+	// Extend the slice to its capacity and check the spare slots.
+	fullSlice := cachedGroup.Users[:cap(cachedGroup.Users)]
+	require.Empty(t, fullSlice[2],
+		"backing array was mutated beyond len: slot 2 contains %q", fullSlice[2])
 }
 
 var basicGroups = []*userv1.Group{


### PR DESCRIPTION
When removing a user from a group, `removeUserFromGroup` gets a pointer to the group object living in the informer cache via the lister, then builds the new user list using append on a sub-slice of it:
```go
  newUsers = append(updatedGroup.Users[0:userIdx], updatedGroup.Users[userIdx+1:]...)
```

Because the sub-slice shares the backing array with the cached object, `append` mutates the cached object's user list in place -- the removed user disappears and the last user gets duplicated. When the informer re-indexes the group after an update event, it diffs the corrupted old object against the new one. Since the removed user is no longer in the corrupted old object, its index entry is never cleaned up and becomes a permanent phantom.

On subsequent logins, `GroupsFor(user)` returns the phantom group from the index. `groupsDiff` sees that the cache already includes the group, matches the provider's desired state, and computes no changes needed -- so the user is never actually added to the group.

`addUserToGroup` has a similar issue. 

This PR fixes this issue by creating a slice with a new backing array to store the updated user list. `addUserToGroup` can simply use the deep-copied object as this already uses a new backing array.