### PR TITLE
chore: bump Go 1.25 and ART images for 4.22

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.24-openshift-4.21
+  tag: rhel-9-release-golang-1.25-openshift-4.22

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/oauth-server
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/images/Dockerfile.rhel
+++ b/images/Dockerfile.rhel
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
 WORKDIR /go/src/github.com/openshift/oauth-server
 COPY . .
 ENV GO_PACKAGE github.com/openshift/oauth-server
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/oauth-server/oauth-server /usr/bin/
 ENTRYPOINT ["/usr/bin/oauth-server"]
 LABEL io.k8s.display-name="OpenShift OAuth Server" \


### PR DESCRIPTION
## Summary
- Bumps `go.mod` from Go 1.24.0 to Go 1.25.0 to match the ART image update
- Cherry-picks ART image changes from #207 (`.ci-operator.yaml` and `images/Dockerfile.rhel` updated to 4.22 builder/base images with Go 1.25)

The ART PR #207 was failing `verify-golang-versions` because it bumped the CI and Dockerfile images to Go 1.25 but `go.mod` was still at 1.24. This PR fixes the mismatch and includes the ART changes, superseding #207.

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `make test-unit` passes
- [x] `make verify` passes (including `verify-golang-versions`)