### PR TITLE
fix typo: 'occured' -> 'occurred' in osinserver error responses

### DIFF
--- a/pkg/oauth/external/handler.go
+++ b/pkg/oauth/external/handler.go
@@ -241,7 +241,7 @@ func (h *Handler) handleError(err error, w http.ResponseWriter, req *http.Reques
 	}
 
 	klog.V(4).Infof("handle error failed for err: %v", err)
-	http.Error(w, "An error occured", http.StatusInternalServerError)
+	http.Error(w, "An error occurred", http.StatusInternalServerError)
 }
 
 // defaultState provides default state-building, validation, and parsing to contain CSRF and "then" redirection

--- a/pkg/osinserver/osinserver.go
+++ b/pkg/osinserver/osinserver.go
@@ -92,7 +92,7 @@ func (s *osinServer) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := osin.OutputJSON(resp, w, r); err != nil {
 		klog.Infof("output JSON through osin: %v", err)
-		http.Error(w, "an internal error occured", http.StatusInternalServerError)
+		http.Error(w, "an internal error occurred", http.StatusInternalServerError)
 	}
 }
 
@@ -112,7 +112,7 @@ func (s *osinServer) handleToken(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := osin.OutputJSON(resp, w, r); err != nil {
 		klog.Infof("output JSON through osin: %v", err)
-		http.Error(w, "an internal error occured", http.StatusInternalServerError)
+		http.Error(w, "an internal error occurred", http.StatusInternalServerError)
 	}
 }
 
@@ -125,6 +125,6 @@ func (s *osinServer) handleInfo(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := osin.OutputJSON(resp, w, r); err != nil {
 		klog.Infof("output JSON through osin: %v", err)
-		http.Error(w, "an internal error occured", http.StatusInternalServerError)
+		http.Error(w, "an internal error occurred", http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
Corrects the spelling of "occurred" in the `http.Error` messages emitted by `pkg/osinserver/osinserver.go` when JSON output fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected typo in internal server error messages across authentication endpoints — "occurred" now displays properly.
  * Ensures consistent, polished wording for 500-level error responses during token, authorization, and info operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->