### PR TITLE
RFE-9481: Add copy-to-clipboard on OAuth token display page

### DIFF
--- a/pkg/server/tokenrequest/tokenrequest.go
+++ b/pkg/server/tokenrequest/tokenrequest.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/openshift/osincli"
 
@@ -144,7 +145,21 @@ func (t *tokenRequest) displayTokenPost(osinOAuthClient *osincli.Client, w http.
 	}
 
 	data.AccessToken = accessData.AccessToken
+	data.OcLoginCommand = formatOcLoginCommand(data.AccessToken, data.PublicMasterURL)
+	data.CurlCommand = formatCurlCommand(data.AccessToken, data.PublicMasterURL)
 	renderToken(w, data)
+}
+
+func formatOcLoginCommand(accessToken, publicMasterURL string) string {
+	return fmt.Sprintf("oc login --token=%s --server=%s", accessToken, publicMasterURL)
+}
+
+func formatCurlCommand(accessToken, publicMasterURL string) string {
+	return fmt.Sprintf(
+		`curl -H "Authorization: Bearer %s" "%s/apis/user.openshift.io/v1/users/~"`,
+		accessToken,
+		strings.TrimRight(publicMasterURL, "/"),
+	)
 }
 
 func displayTokenStart(osinOAuthClient *osincli.Client, w http.ResponseWriter, req *http.Request, data *sharedData) (*osincli.AuthorizeData, bool) {
@@ -179,6 +194,8 @@ type tokenData struct {
 	sharedData
 
 	AccessToken     string
+	OcLoginCommand  string
+	CurlCommand     string
 	PublicMasterURL string
 	LogoutURL       string
 }
@@ -216,12 +233,70 @@ const cssStyle = `
 	pre      { padding-left: 1em; border-radius: 5px; color: #003d6e; background-color: #EAEDF0; padding: 1.5em 0 1.5em 4.5em; white-space: normal; text-indent: -2em; }
 	a        { color: #00f; text-decoration: none; }
 	a:hover  { text-decoration: underline; }
-	button   { background: none; border: none; color: #00f; text-decoration: none; font: inherit; padding: 0; }
-	button:hover { text-decoration: underline; cursor: pointer; }
+	button, .copy-button { background: none; border: none; color: #00f; text-decoration: none; font: inherit; padding: 0; }
+	button:hover, .copy-button:hover { text-decoration: underline; cursor: pointer; }
+	.copy-heading { display: inline; }
+	.copy-heading .copy-button { font-size: 0.85em; margin-left: 0.75em; }
 	@media (min-width: 768px) {
 		.nowrap { white-space: nowrap; }
 	}
 </style>
+`
+
+const copyToClipboardScript = `
+<script>
+(function () {
+  var copyLabel = 'Copy to clipboard';
+  var copiedLabel = 'Copied';
+
+  function showCopied(button) {
+    button.textContent = copiedLabel;
+    button.setAttribute('aria-label', copiedLabel);
+    window.setTimeout(function () {
+      button.textContent = copyLabel;
+      button.setAttribute('aria-label', copyLabel);
+    }, 1250);
+  }
+
+  function fallbackCopy(text, button) {
+    var textarea = document.createElement('textarea');
+    textarea.value = text;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'absolute';
+    textarea.style.left = '-9999px';
+    document.body.appendChild(textarea);
+    textarea.select();
+    try {
+      if (document.execCommand('copy')) {
+        showCopied(button);
+      }
+    } finally {
+      document.body.removeChild(textarea);
+    }
+  }
+
+  function copyText(text, button) {
+    if (!text) {
+      return;
+    }
+    if (navigator.clipboard && window.isSecureContext) {
+      navigator.clipboard.writeText(text).then(function () {
+        showCopied(button);
+      }).catch(function () {
+        fallbackCopy(text, button);
+      });
+      return;
+    }
+    fallbackCopy(text, button);
+  }
+
+  document.querySelectorAll('[data-copy-text]').forEach(function (button) {
+    button.addEventListener('click', function () {
+      copyText(button.getAttribute('data-copy-text'), button);
+    });
+  });
+})();
+</script>
 `
 
 var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(
@@ -229,14 +304,15 @@ var tokenTemplate = template.Must(template.New("tokenTemplate").Parse(
 {{ if .Error }}
   {{ .Error }}
 {{ else }}
-  <h2>Your API token is</h2>
+  <h2 class="copy-heading">Your API token is <button type="button" class="copy-button" data-copy-text="{{.AccessToken}}" aria-label="Copy to clipboard">Copy to clipboard</button></h2>
   <code>{{.AccessToken}}</code>
 
-  <h2>Log in with this token</h2>
+  <h2 class="copy-heading">Log in with this token <button type="button" class="copy-button" data-copy-text="{{.OcLoginCommand}}" aria-label="Copy to clipboard">Copy to clipboard</button></h2>
   <pre>oc login <span class="nowrap">--token={{.AccessToken}}</span> <span class="nowrap">--server={{.PublicMasterURL}}</span></pre>
 
-  <h3>Use this token directly against the API</h3>
+  <h3 class="copy-heading">Use this token directly against the API <button type="button" class="copy-button" data-copy-text="{{.CurlCommand}}" aria-label="Copy to clipboard">Copy to clipboard</button></h3>
   <pre>curl <span class="nowrap">-H "Authorization: Bearer {{.AccessToken}}"</span> <span class="nowrap">"{{.PublicMasterURL}}/apis/user.openshift.io/v1/users/~"</span></pre>
+  ` + copyToClipboardScript + `
 {{ end }}
 
 <br><br>

--- a/pkg/server/tokenrequest/tokenrequest_test.go
+++ b/pkg/server/tokenrequest/tokenrequest_test.go
@@ -1,0 +1,182 @@
+package tokenrequest
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/openshift/oauth-server/pkg/server/csrf"
+)
+
+func TestFormatOcLoginCommand(t *testing.T) {
+	token := "sha256~abc123"
+	server := "https://api.example.com:6443"
+
+	got := formatOcLoginCommand(token, server)
+	want := "oc login --token=sha256~abc123 --server=https://api.example.com:6443"
+	if got != want {
+		t.Fatalf("formatOcLoginCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestFormatCurlCommand(t *testing.T) {
+	token := "sha256~abc123"
+	server := "https://api.example.com:6443/"
+
+	got := formatCurlCommand(token, server)
+	want := `curl -H "Authorization: Bearer sha256~abc123" "https://api.example.com:6443/apis/user.openshift.io/v1/users/~"`
+	if got != want {
+		t.Fatalf("formatCurlCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderTokenIncludesCopyToClipboardControls(t *testing.T) {
+	data := tokenData{
+		sharedData: sharedData{
+			RequestURL: "/oauth/token/request",
+		},
+		AccessToken:     "sha256~token-value",
+		OcLoginCommand:  formatOcLoginCommand("sha256~token-value", "https://api.example.com:6443"),
+		CurlCommand:     formatCurlCommand("sha256~token-value", "https://api.example.com:6443"),
+		PublicMasterURL: "https://api.example.com:6443",
+	}
+
+	var buf bytes.Buffer
+	renderToken(&buf, data)
+	body := buf.String()
+
+	expectContains(t, body, []string{
+		"Your API token is",
+		"Log in with this token",
+		"Use this token directly against the API",
+		`class="copy-button"`,
+		`aria-label="Copy to clipboard"`,
+		`data-copy-text="sha256~token-value"`,
+		`data-copy-text="oc login --token=sha256~token-value --server=https://api.example.com:6443"`,
+		`data-copy-text="curl -H &#34;Authorization: Bearer sha256~token-value&#34; &#34;https://api.example.com:6443/apis/user.openshift.io/v1/users/~&#34;"`,
+		"navigator.clipboard",
+		"document.execCommand('copy')",
+		`<a href="/oauth/token/request">Request another token</a>`,
+	})
+
+	if strings.Count(body, `class="copy-button"`) != 3 {
+		t.Fatalf("expected 3 copy buttons, got %d in:\n%s", strings.Count(body, `class="copy-button"`), body)
+	}
+}
+
+func TestRenderTokenEscapesSpecialCharactersInCopyAttributes(t *testing.T) {
+	token := `sha256~test"onclick='alert(1)'`
+	server := "https://api.example.com:6443"
+
+	data := tokenData{
+		sharedData: sharedData{
+			RequestURL: "/oauth/token/request",
+		},
+		AccessToken:     token,
+		OcLoginCommand:  formatOcLoginCommand(token, server),
+		CurlCommand:     formatCurlCommand(token, server),
+		PublicMasterURL: server,
+	}
+
+	var buf bytes.Buffer
+	renderToken(&buf, data)
+	body := buf.String()
+
+	if strings.Contains(body, `data-copy-text="sha256~test"onclick`) {
+		t.Fatalf("token copy attribute was not HTML-escaped:\n%s", body)
+	}
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatalf("unexpected unescaped script content in output:\n%s", body)
+	}
+	expectContains(t, body, []string{
+		`data-copy-text="sha256~test&#34;onclick=&#39;alert(1)&#39;"`,
+	})
+}
+
+func TestRenderTokenErrorStateOmitsCopyControls(t *testing.T) {
+	data := tokenData{
+		sharedData: sharedData{
+			Error:      "Error checking token",
+			RequestURL: "/oauth/token/request",
+		},
+	}
+
+	var buf bytes.Buffer
+	renderToken(&buf, data)
+	body := buf.String()
+
+	expectContains(t, body, []string{
+		"Error checking token",
+		`<a href="/oauth/token/request">Request another token</a>`,
+	})
+	if strings.Contains(body, `class="copy-button"`) {
+		t.Fatalf("error state should not render copy buttons:\n%s", body)
+	}
+}
+
+func TestRenderFormDisplayTokenStepUnchanged(t *testing.T) {
+	data := formData{
+		sharedData: sharedData{
+			RequestURL: "/oauth/token/request",
+		},
+		Action: "https://oauth.example.com/oauth/token/display",
+		Code:   "auth-code",
+		CSRF:   "csrf-token",
+	}
+
+	var buf bytes.Buffer
+	renderForm(&buf, data)
+	body := buf.String()
+
+	expectContains(t, body, []string{
+		`action="https://oauth.example.com/oauth/token/display"`,
+		`name="code" value="auth-code"`,
+		`name="csrf" value="csrf-token"`,
+		"Display Token",
+	})
+	if strings.Contains(body, `class="copy-button"`) {
+		t.Fatalf("display token form should not include copy buttons:\n%s", body)
+	}
+}
+
+func TestDisplayTokenPostRejectsInvalidCSRF(t *testing.T) {
+	handler := &tokenRequest{
+		csrf: &csrf.FakeCSRF{Token: "expected-csrf"},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token/display", strings.NewReader("csrf=wrong"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	handler.displayTokenPost(nil, rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusBadRequest, rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Could not check CSRF token") {
+		t.Fatalf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestDisplayTokenRejectsUnsupportedMethod(t *testing.T) {
+	handler := &tokenRequest{}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/oauth/token/display", nil)
+	handler.displayToken(nil, rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusMethodNotAllowed, rec.Code, rec.Body.String())
+	}
+}
+
+func expectContains(t *testing.T, body string, expected []string) {
+	t.Helper()
+	for _, fragment := range expected {
+		if !strings.Contains(body, fragment) {
+			t.Fatalf("expected body to contain %q, got:\n%s", fragment, body)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds **Copy to clipboard** buttons on the OAuth token display page (`/oauth/token/display`) for:

- API token
- `oc login --token=... --server=...` command
- `curl` example for direct API use

## Motivation

- [RFE-9481](https://redhat.atlassian.net/browse/RFE-9481)
- Related: [CONSOLE-2156](https://redhat.atlassian.net/browse/CONSOLE-2156)

Users currently must manually select and copy text after **Display Token**. This adds one-click copy while keeping the existing security flow.

## Security

- **Display Token** POST + CSRF flow is unchanged (required for CVE mitigation).
- Copy happens only on explicit button click (no auto-copy on page load).
- Copy text is passed via HTML-escaped `data-copy-text` attributes (not inline JS string interpolation).

## Test plan

- [x] `go test ./pkg/server/tokenrequest/...`
- [ ] Manual cluster validation (skipped by author; recommend reviewer verify on a dev cluster)

## Files changed

- `pkg/server/tokenrequest/tokenrequest.go` — copy UI + helpers
- `pkg/server/tokenrequest/tokenrequest_test.go` — template, escaping, CSRF tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added copyable commands alongside the access token display, including an `oc login` command and a direct `curl` request.
  * Improved the token screen with clipboard copy controls for easier reuse.

* **Bug Fixes**
  * Updated copy behavior to handle special characters safely and avoid malformed copied content.
  * Added validation so invalid requests and unsupported methods return the appropriate errors.

* **Tests**
  * Added coverage for command generation, token rendering, copy controls, escaping, and request validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->