### PR TITLE
Validate then parameter in grant handler to prevent open redirects

### DIFF
--- a/pkg/server/grant/grant.go
+++ b/pkg/server/grant/grant.go
@@ -121,6 +121,10 @@ func (l *Grant) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 func (l *Grant) handleForm(user user.Info, w http.ResponseWriter, req *http.Request) {
 	q := req.URL.Query()
 	then := q.Get(thenParam)
+	if len(then) > 0 && !redirect.IsServerRelativeURL(then) {
+		l.failed("Invalid redirect", w, req)
+		return
+	}
 	clientID := q.Get(clientIDParam)
 	scopes := scopecovers.Split(q.Get(scopeParam))
 	redirectURI := q.Get(redirectURIParam)
@@ -202,6 +206,9 @@ func (l *Grant) handleGrant(user user.Info, w http.ResponseWriter, req *http.Req
 	}
 
 	then := req.PostFormValue(thenParam)
+	if !redirect.IsServerRelativeURL(then) {
+		then = ""
+	}
 	scopes := scopecovers.Join(req.PostForm[scopeParam])
 	username := req.PostFormValue(userNameParam)
 

--- a/pkg/server/grant/grant_test.go
+++ b/pkg/server/grant/grant_test.go
@@ -392,6 +392,88 @@ func TestGrant(t *testing.T) {
 			ExpectStatusCode: 302,
 			ExpectRedirect:   "/authorize?error=access_denied",
 		},
+
+		"reject open redirect on approve": {
+			CSRF:           &csrf.FakeCSRF{Token: "test"},
+			Auth:           goodAuth("username"),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
+			AuthRegistry:   emptyAuthRegistry(),
+			Path:           "/grant",
+			PostValues: url.Values{
+				"approve":      {"true"},
+				"client_id":    {"myclient"},
+				"scope":        {"myscope1", "myscope2"},
+				"redirect_uri": {"/myredirect"},
+				"then":         {"https://evil.example.com"},
+				"csrf":         {"test"},
+				"user_name":    {"username"},
+			},
+
+			ExpectStatusCode:        200,
+			ExpectCreatedAuthScopes: []string{"myscope1", "myscope2"},
+			ExpectContains: []string{
+				"granted",
+				"no redirect",
+			},
+		},
+
+		"reject open redirect on deny": {
+			CSRF:           &csrf.FakeCSRF{Token: "test"},
+			Auth:           goodAuth("username"),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
+			AuthRegistry:   emptyAuthRegistry(),
+			Path:           "/grant",
+			PostValues: url.Values{
+				"deny":         {"true"},
+				"client_id":    {"myclient"},
+				"scope":        {"myscope1", "myscope2"},
+				"redirect_uri": {"/myredirect"},
+				"then":         {"https://evil.example.com"},
+				"csrf":         {"test"},
+				"user_name":    {"username"},
+			},
+
+			ExpectStatusCode: 200,
+			ExpectContains: []string{
+				"denied",
+				"no redirect",
+			},
+		},
+
+		"reject open redirect on form display": {
+			CSRF:           &csrf.FakeCSRF{Token: "test"},
+			Auth:           goodAuth("username"),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
+			AuthRegistry:   emptyAuthRegistry(),
+			Path:           "/grant?client_id=myclient&scope=myscope1%20myscope2&redirect_uri=/myredirect&then=https://evil.example.com",
+
+			ExpectStatusCode: 200,
+			ExpectContains:   []string{"Invalid redirect"},
+		},
+
+		"reject protocol-relative redirect on approve": {
+			CSRF:           &csrf.FakeCSRF{Token: "test"},
+			Auth:           goodAuth("username"),
+			ClientRegistry: goodClientRegistry("myclient", []string{"myredirect"}, []string{"myscope1", "myscope2"}),
+			AuthRegistry:   emptyAuthRegistry(),
+			Path:           "/grant",
+			PostValues: url.Values{
+				"approve":      {"true"},
+				"client_id":    {"myclient"},
+				"scope":        {"myscope1", "myscope2"},
+				"redirect_uri": {"/myredirect"},
+				"then":         {"//evil.example.com/path"},
+				"csrf":         {"test"},
+				"user_name":    {"username"},
+			},
+
+			ExpectStatusCode:        200,
+			ExpectCreatedAuthScopes: []string{"myscope1", "myscope2"},
+			ExpectContains: []string{
+				"granted",
+				"no redirect",
+			},
+		},
 	}
 
 	for k, testCase := range testCases {


### PR DESCRIPTION
## Summary
- Validate the `then` URL parameter with `IsServerRelativeURL` in the grant handler's POST path (`handleGrant`) to block redirects to external sites after grant approve/deny
- Add defense-in-depth validation in the GET path (`handleForm`) to reject malicious `then` values before they are embedded in the HTML form
- Add 4 test cases covering absolute URL and protocol-relative URL redirect attempts

## Test plan
- [x] All 21 grant handler tests pass (17 existing + 4 new)
- [x] Open redirect blocked on approve, deny, and form display
- [x] Protocol-relative URLs (`//evil.com`) blocked
- [x] Existing redirect flows (server-relative `then`, empty `then`) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blocked external redirect targets in grant approval and denial flows.
  * Invalid redirect parameters now remain on the local page instead of sending users to untrusted destinations.
  * Added validation for both absolute and protocol-relative redirect URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->