### PR TITLE
OCPBUGS-56908: Sanitize IDP name in group sync annotation key to fix spaces

### DIFF
--- a/pkg/groupmapper/groupmapper.go
+++ b/pkg/groupmapper/groupmapper.go
@@ -3,7 +3,9 @@ package groupmapper
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"slices"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -25,6 +27,23 @@ const (
 	groupGeneratedKey = "oauth.openshift.io/generated"
 	groupSyncedKeyFmt = "oauth.openshift.io/idp.%s"
 )
+
+var invalidAnnotationChars = regexp.MustCompile(`[^A-Za-z0-9\-_.]`)
+
+// sanitizeIDPName replaces characters that are invalid in a Kubernetes
+// annotation key name segment with '-' and trims any leading/trailing
+// non-alphanumeric characters so the result satisfies the validation
+// regex: ([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]
+func sanitizeIDPName(name string) string {
+	sanitized := invalidAnnotationChars.ReplaceAllString(name, "-")
+	sanitized = strings.TrimLeft(sanitized, "-_.")
+	sanitized = strings.TrimRight(sanitized, "-_.")
+	return sanitized
+}
+
+func groupSyncedAnnotationKey(idpName string) string {
+	return fmt.Sprintf(groupSyncedKeyFmt, sanitizeIDPName(idpName))
+}
 
 var _ authapi.UserIdentityMapper = &UserGroupsMapper{}
 
@@ -138,7 +157,7 @@ func (m *UserGroupsMapper) removeUserFromGroup(idpName, username, group string) 
 	}
 
 	// don't perform any actions on the group if it hasn't been synced for this IdP
-	if updatedGroup.Annotations[fmt.Sprintf(groupSyncedKeyFmt, idpName)] != "synced" {
+	if updatedGroup.Annotations[groupSyncedAnnotationKey(idpName)] != "synced" {
 		return nil
 	}
 
@@ -167,8 +186,8 @@ func (m *UserGroupsMapper) addUserToGroup(idpName, username, group string) error
 				ObjectMeta: metav1.ObjectMeta{
 					Name: group,
 					Annotations: map[string]string{
-						fmt.Sprintf(groupSyncedKeyFmt, idpName): "synced",
-						groupGeneratedKey:                       "true",
+						groupSyncedAnnotationKey(idpName): "synced",
+						groupGeneratedKey:                 "true",
 					},
 				},
 				Users: []string{username},
@@ -188,7 +207,7 @@ func (m *UserGroupsMapper) addUserToGroup(idpName, username, group string) error
 	var onlyAddAnnotation bool
 	for _, u := range updatedGroup.Users {
 		if u == username {
-			if updatedGroup.Annotations[fmt.Sprintf(groupSyncedKeyFmt, idpName)] != "synced" {
+			if updatedGroup.Annotations[groupSyncedAnnotationKey(idpName)] != "synced" {
 				onlyAddAnnotation = true
 				break
 			}
@@ -200,7 +219,7 @@ func (m *UserGroupsMapper) addUserToGroup(idpName, username, group string) error
 	if !onlyAddAnnotation {
 		updatedGroupCopy.Users = append(updatedGroupCopy.Users, username)
 	}
-	updatedGroupCopy.Annotations[fmt.Sprintf(groupSyncedKeyFmt, idpName)] = "synced"
+	updatedGroupCopy.Annotations[groupSyncedAnnotationKey(idpName)] = "synced"
 
 	_, err = m.groupsClient.Update(context.TODO(), updatedGroupCopy, metav1.UpdateOptions{})
 	return err

--- a/pkg/groupmapper/groupmapper_test.go
+++ b/pkg/groupmapper/groupmapper_test.go
@@ -32,6 +32,7 @@ import (
 )
 
 const testIDPName = "test-idp"
+const testIDPNameWithSpaces = "Microsoft Entra ID"
 
 type mockUserMapper struct {
 	userInfo kuser.DefaultInfo
@@ -623,6 +624,83 @@ func TestAddUserToGroup_DoesNotMutateCachedObject(t *testing.T) {
 	fullSlice := cachedGroup.Users[:cap(cachedGroup.Users)]
 	require.Empty(t, fullSlice[2],
 		"backing array was mutated beyond len: slot 2 contains %q", fullSlice[2])
+}
+
+func TestSanitizeIDPName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no special characters",
+			input:    "my-idp",
+			expected: "my-idp",
+		},
+		{
+			name:     "spaces replaced with dashes",
+			input:    "Microsoft Entra ID",
+			expected: "Microsoft-Entra-ID",
+		},
+		{
+			name:     "multiple spaces",
+			input:    "AIF - Keycloak",
+			expected: "AIF---Keycloak",
+		},
+		{
+			name:     "leading and trailing spaces",
+			input:    " my idp ",
+			expected: "my-idp",
+		},
+		{
+			name:     "dots and underscores preserved",
+			input:    "my.idp_name",
+			expected: "my.idp_name",
+		},
+		{
+			name:     "special characters replaced",
+			input:    "idp@company#1",
+			expected: "idp-company-1",
+		},
+		{
+			name:     "already valid",
+			input:    "simple-idp-123",
+			expected: "simple-idp-123",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeIDPName(tt.input)
+			if got != tt.expected {
+				t.Errorf("sanitizeIDPName(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestAddUserToGroup_IDPNameWithSpaces(t *testing.T) {
+	const testGroupName = "test-group"
+
+	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+	fakeUserClient := fakeuserclient.NewSimpleClientset()
+
+	m := &UserGroupsMapper{
+		groupsLister: userlisterv1.NewGroupLister(indexer),
+		groupsClient: fakeUserClient.UserV1().Groups(),
+	}
+
+	err := m.addUserToGroup(testIDPNameWithSpaces, "user1", testGroupName)
+	require.NoError(t, err)
+
+	group, err := fakeUserClient.UserV1().Groups().Get(context.Background(), testGroupName, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	expectedKey := "oauth.openshift.io/idp.Microsoft-Entra-ID"
+	val, ok := group.Annotations[expectedKey]
+	require.True(t, ok, "expected annotation key %q to exist, got annotations: %v", expectedKey, group.Annotations)
+	require.Equal(t, "synced", val)
+
+	require.Equal(t, []string{"user1"}, []string(group.Users))
 }
 
 var basicGroups = []*userv1.Group{


### PR DESCRIPTION
**Bug**
When an OIDC identity provider has both a name with spaces and `claims.groups` configured, the OAuth server attempts to create/update a `Group` resource with an invalid annotation key. The API server rejects this, and the user sees "An authentication error occurred" with no further detail in the UI.

Error from oauth-openshift pod logs:
```
Group.user.openshift.io "testgroup" is invalid: metadata.annotations:
Invalid value: "oauth.openshift.io/idp.Microsoft Entra ID": name part must
consist of alphanumeric characters, '-', '_' or '.', and must start and end
with an alphanumeric character
```

**Fix**

Sanitize IDP names before using them in Kubernetes annotation keys during group sync. Invalid characters (spaces, etc.) are replaced with dashes so that IDP names like "Microsoft Entra ID" produce valid annotation keys `oauth.openshift.io/idp.Microsoft-Entra-ID` instead of being rejected by the API server and breaking authentication.

**Test Plan** 

Verify that go test ./pkg/groupmapper/... passes with all existing and new tests. TestSanitizeIDPName covers spaces, special characters, leading/trailing trimming, and passthrough of already valid names. TestAddUserToGroup_IDPNameWithSpaces creates a group using IDP name "Microsoft Entra ID" and confirms the annotation key is sanitized to `oauth.openshift.io/idp.Microsoft-Entra-ID`. Manually test by configuring an OpenID Connect IDP with spaces in the name and group claims enabled, then log in via the console and verify authentication succeeds and groups are synced correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved group synchronization for identity providers with spaces or special characters in their names.
  * Group annotations now use valid, consistently sanitized identity provider names while preserving supported dots and underscores.
  * User-to-group assignments now correctly reference sanitized identity provider names.
  * Prevented invalid annotation keys from interfering with group creation and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->